### PR TITLE
Bulk update to C++-17

### DIFF
--- a/src/cas/cas.cpp
+++ b/src/cas/cas.cpp
@@ -640,7 +640,7 @@ namespace uima {
       deleteSofaID = true;
     }
     // test if this is the reserved name
-    if ( 0 == sid->getSofaId().compare(UnicodeString(CAS::NAME_DEFAULT_SOFA)) ) {
+    if ( 0 == sid->getSofaId().compare(icu::UnicodeString(CAS::NAME_DEFAULT_SOFA)) ) {
       ErrorMessage errMessage(UIMA_MSG_ID_EXC_SOFA_NAME_ALREADY_EXISTS);
       errMessage.addParam( localViewName );
       UIMA_EXC_THROW_NEW(DuplicateSofaNameException,
@@ -912,13 +912,13 @@ namespace uima {
   */
 
   SofaFS CAS::createLocalSofa(const char* sofaName, const char* mimeType) {
-    UnicodeString const uName(sofaName, strlen(sofaName), "utf8");
-    UnicodeString const uMime(mimeType, strlen(mimeType), "utf8");
+    icu::UnicodeString const uName(sofaName, strlen(sofaName), "utf8");
+    icu::UnicodeString const uMime(mimeType, strlen(mimeType), "utf8");
     return createSofa(uName, uMime);
   }
 
   SofaFS CAS::createSofa(const SofaID & sofaName, const char* mimeType) {
-    UnicodeString const uMime(mimeType, strlen(mimeType), "utf8");
+    icu::UnicodeString const uMime(mimeType, strlen(mimeType), "utf8");
     return createSofa(sofaName.getSofaId(), uMime);
   }
 
@@ -959,7 +959,7 @@ namespace uima {
   }
 
   SofaFS CAS::getSofa(char* sofaName) {
-    UnicodeString const uName(sofaName, strlen(sofaName), "utf8");
+    icu::UnicodeString const uName(sofaName, strlen(sofaName), "utf8");
     return getSofa(uName);
   }
 
@@ -1212,7 +1212,7 @@ namespace uima {
   }
 
   void SofaFS::setRemoteSofaURI(const char* aURI) {
-    UnicodeString const ucURI(aURI, strlen(aURI), "utf8");
+    icu::UnicodeString const ucURI(aURI, strlen(aURI), "utf8");
     return setRemoteSofaURI(ucURI);
   }
 

--- a/src/cas/featurestructure.cpp
+++ b/src/cas/featurestructure.cpp
@@ -470,7 +470,7 @@ namespace uima {
         }
       }
       if (! bStringFound) {
-        UnicodeString us(uls.getBuffer(), uls.length() );
+	icu::UnicodeString us(uls.getBuffer(), uls.length() );
         ErrorMessage errMess(UIMA_MSG_ID_EXC_WRONG_STRING_VALUE);
         errMess.addParam(us);
         errMess.addParam(crTypeSystem.getTypeName(tyRangeType) );

--- a/src/cas/internal_casdeserializer.cpp
+++ b/src/cas/internal_casdeserializer.cpp
@@ -652,7 +652,7 @@ namespace uima {
       FSIterator fsIt = fsIdx.iterator();
       while (fsIt.isValid()) {
         SofaFS aSofa = (SofaFS) fsIt.get();
-        if ( 0 == aSofa.getSofaID().compare(UnicodeString(CAS::NAME_DEFAULT_SOFA)) ) {
+        if ( 0 == aSofa.getSofaID().compare(icu::UnicodeString(CAS::NAME_DEFAULT_SOFA)) ) {
           rCAS.registerInitialSofa();
         } else {
           // only bump sofa count if not initial View

--- a/src/cas/internal_casserializer.cpp
+++ b/src/cas/internal_casserializer.cpp
@@ -467,7 +467,7 @@ namespace uima {
           vector<uima::lowlevel::internal::SingleIndex*> const & crSingleIndexes =
             crIndexRep->getAllSingleIndexesForType(vecAllTypes[i]);
           for (size_t j=0; j<crSingleIndexes.size(); ++j) {
-            auto_ptr<uima::lowlevel::IndexIterator> apIt(crSingleIndexes[j]->createIterator());
+            unique_ptr<uima::lowlevel::IndexIterator> apIt(crSingleIndexes[j]->createIterator());
             for (apIt->moveToFirst(); apIt->isValid(); apIt->moveToNext()) {
               uima::lowlevel::TyHeapCell pHeapCell = (uima::lowlevel::TyHeapCell) apIt->get();
               SerializedCAS::TyNum tyFSHeapIndex =  (SerializedCAS::TyNum) pHeapCell;

--- a/src/cas/lowlevel_index.cpp
+++ b/src/cas/lowlevel_index.cpp
@@ -75,7 +75,7 @@ namespace uima {
      * generic implementation of find().
      */
     TyFS IndexABase::find(TyFS fs) const {
-      auto_ptr<IndexIterator> it(createIterator());
+      unique_ptr<IndexIterator> it(createIterator());
       assert( EXISTS(it.get()) );
       for (it->moveToFirst(); it->isValid(); it->moveToNext() ) {
         TyFS nextFS = it->get();

--- a/src/cas/lowlevel_indexrepository.cpp
+++ b/src/cas/lowlevel_indexrepository.cpp
@@ -187,7 +187,7 @@ namespace uima {
           vector<uima::lowlevel::internal::SingleIndex*> const & crSingleIndexes =
             getAllSingleIndexesForType(iv_usedIndexes[i]);
           for (size_t j=0; j<crSingleIndexes.size(); ++j) {
-            auto_ptr<uima::lowlevel::IndexIterator> apIt(crSingleIndexes[j]->createIterator());
+            unique_ptr<uima::lowlevel::IndexIterator> apIt(crSingleIndexes[j]->createIterator());
             for (apIt->moveToFirst(); apIt->isValid(); apIt->moveToNext()) {
               uima::lowlevel::TyHeapCell pHeapCell = (uima::lowlevel::TyHeapCell) apIt->get();
               TyFS tyFSHeapIndex =  pHeapCell;

--- a/src/cas/lowlevel_internal_indexes.cpp
+++ b/src/cas/lowlevel_internal_indexes.cpp
@@ -567,7 +567,7 @@ namespace uima {
 
       // generic implementation here, may be optimized for subclasses
       bool SingleIndex::contains(TyFS tyFS) const {
-        auto_ptr<IndexIterator> it( createIterator() );
+        unique_ptr<IndexIterator> it( createIterator() );
         for (it->moveToFirst(); it->isValid(); it->moveToNext()) {
           if ( it->get() == tyFS ) {
             return true;
@@ -589,7 +589,7 @@ namespace uima {
 
       TyFS ComparatorSingleIndex::find(TyFS fs) const {
         assert( EXISTS(iv_cpComparator) );
-        auto_ptr<IndexIterator> it(createIterator());
+        unique_ptr<IndexIterator> it(createIterator());
         assert( EXISTS(it.get()) );
         TyFS result = 0;
         for (it->moveToFirst(); it->isValid(); it->moveToNext() ) {

--- a/src/cas/uima/featurestructure.hpp
+++ b/src/cas/uima/featurestructure.hpp
@@ -136,6 +136,11 @@ namespace uima {
      */
     FeatureStructure();
 
+    // This is required to allow safe delete calls (it makes the
+    // class polymorphic).
+    virtual ~FeatureStructure(){} 
+
+    
     /**
      * Returns the CAS object in which this feature structure lives.
      */

--- a/src/cas/uima/lowlevel_internal_indexes.hpp
+++ b/src/cas/uima/lowlevel_internal_indexes.hpp
@@ -346,7 +346,7 @@ namespace uima {
           TyComponents::const_iterator cit;
           for (cit = iv_tyComponents.begin(); cit != iv_tyComponents.end(); ++cit) {
             SingleIndex const * index = (*cit);
-	    std::auto_ptr<IndexIterator> apit( index->createIterator() );
+	    std::unique_ptr<IndexIterator> apit( index->createIterator() );
             for (apit->moveToFirst(); apit->isValid(); apit->moveToNext()) {
               iv_cache.insert(iv_cache.end(), apit->get() );
             }

--- a/src/cas/uima/xcasdeserializer.hpp
+++ b/src/cas/uima/xcasdeserializer.hpp
@@ -105,7 +105,7 @@ namespace uima {
     /**
      * Deserialize given an XCAS filename UnicodeString and input CAS 
      */
-    static void deserialize(UnicodeString & xcasfilename, CAS &);
+  static void deserialize(icu::UnicodeString & xcasfilename, CAS &);
 
     /**
      * Deserialize given an XCAS filename, input CAS, and the 

--- a/src/cas/uima/xcasdeserializer_handler.hpp
+++ b/src/cas/uima/xcasdeserializer_handler.hpp
@@ -102,7 +102,7 @@ namespace uima {
                       const   XMLCh* const    qname,
                       const Attributes& attrs);
     void characters(const XMLCh* const chars,
-                    const unsigned int length);
+                    const XMLSize_t length);
     void endDocument();
     void endElement(const XMLCh* const uri,
                     const XMLCh* const localname,
@@ -120,15 +120,15 @@ namespace uima {
 
   private:
 
-    void readFS(UnicodeString & qualifiedName, const Attributes & attrs);
+    void readFS(icu::UnicodeString & qualifiedName, const Attributes & attrs);
     void readFS(lowlevel::TyFS addr, const Attributes  & attrs, bool toIndex);
-    void handleFeature(lowlevel::TyFS addr, UnicodeString & featName, UnicodeString & featVal, bool lenient);
-    void handleFeature(Type & type, lowlevel::TyFS addr, UnicodeString & featName, UnicodeString & featVal,
+    void handleFeature(lowlevel::TyFS addr, icu::UnicodeString & featName, icu::UnicodeString & featVal, bool lenient);
+    void handleFeature(Type & type, lowlevel::TyFS addr, icu::UnicodeString & featName, icu::UnicodeString & featVal,
                        bool lenient);
     void finalizeFS(FSInfo & fsInfo);
     void readArray(Type & type, const Attributes & attrs);
-    void readArrayElement(UnicodeString & qualifiedName, const Attributes & attrs);
-    void addArrayElement(UnicodeString & buffer);
+    void readArrayElement(icu::UnicodeString & qualifiedName, const Attributes & attrs);
+    void addArrayElement(icu::UnicodeString & buffer);
     void finalizeArray(Type & type, lowlevel::TyFS addr, FSInfo & fsInfo);
 
     const Locator *  iv_locator;
@@ -136,14 +136,14 @@ namespace uima {
     internal::CASImpl & iv_casimpl;
     const lowlevel::TypeSystem * iv_typesystem;
     int iv_state;
-    UnicodeString buffer;
+    icu::UnicodeString buffer;
 
     // The address of the most recently created FS.  Needed for array elements
     // and embedded feature values.
     lowlevel::TyFS currentAddr;
 
     // The name of the content feature, if we've seen one.
-    UnicodeString currentContentFeat;
+    icu::UnicodeString currentContentFeat;
 
     // The current position when parsing array elements.
     size_t arrayPos;

--- a/src/cas/uima/xmideserializer.hpp
+++ b/src/cas/uima/xmideserializer.hpp
@@ -100,7 +100,7 @@ namespace uima {
     /**
      * Deserialize given an XMI filename UnicodeString and input CAS 
      */
-    static void deserialize(UnicodeString & xmifilename, CAS &, bool lenient=false);
+  static void deserialize(icu::UnicodeString & xmifilename, CAS &, bool lenient=false);
 
     /**
      * Deserialize given an XMI InputSource and input CAS 
@@ -122,7 +122,7 @@ namespace uima {
      * Deserialize given an XMI filename UnicodeString, input CAS, and
 		 * XmiSerializationData.
      */
-    static void deserialize(UnicodeString & xmifilename, CAS &, XmiSerializationSharedData & sharedData);
+  static void deserialize(icu::UnicodeString & xmifilename, CAS &, XmiSerializationSharedData & sharedData);
 
   };
 

--- a/src/cas/uima/xmideserializer_handler.hpp
+++ b/src/cas/uima/xmideserializer_handler.hpp
@@ -87,7 +87,7 @@ namespace uima {
                       const   XMLCh* const    qname,
                       const Attributes& attrs);
     void characters(const XMLCh* const chars,
-                    const unsigned int length);
+                    const XMLSize_t length);
     void endDocument();
     void endElement(const XMLCh* const uri,
                     const XMLCh* const localname,
@@ -105,19 +105,19 @@ namespace uima {
 
   private:
   
-    //void readFS(UnicodeString & qualifiedName, const Attributes & attrs);
-    void readFS(UnicodeString & nsUri,
-		        UnicodeString & localName,
-				    UnicodeString & qualifiedName, 
+    //void readFS(icu:UnicodeString & qualifiedName, const Attributes & attrs);
+    void readFS(icu::UnicodeString & nsUri,
+		icu::UnicodeString & localName,
+		icu::UnicodeString & qualifiedName, 
 				    const Attributes & attrs);
     void readFS(lowlevel::TyFS addr, const Attributes  & attrs, bool toIndex);
     void handleFeature(lowlevel::TyFS addr, 
-		         UnicodeString & featName, 
-					   UnicodeString & featVal, 
+		       icu::UnicodeString & featName, 
+		       icu::UnicodeString & featVal, 
 					   bool lenient);
 	  void handleFeature(Type & type, lowlevel::TyFS addr, 
 					   lowlevel::TyFSFeature featCode, 
-					   UnicodeString & featVal,
+			     icu::UnicodeString & featVal,
              bool lenient);
 
     void finalizeFS(int addr);
@@ -128,14 +128,14 @@ namespace uima {
     internal::CASImpl & iv_casimpl;
     const lowlevel::TypeSystem * iv_typesystem;
     int iv_state;
-    UnicodeString buffer;
+    icu::UnicodeString buffer;
 
     // The address of the most recently created FS.  Needed for array elements
     // and embedded feature values.
     lowlevel::TyFS currentAddr;
 
     // The name of the content feature, if we've seen one.
-    UnicodeString currentContentFeat;
+    icu::UnicodeString currentContentFeat;
 
     // The current position when parsing array elements.
     size_t arrayPos;
@@ -155,33 +155,33 @@ namespace uima {
 
     int nextIndex;
 
-		UnicodeString xmiElementName2uimaTypeName(UnicodeString& nameSpaceURI, UnicodeString& localName);
-		int createByteArray(UnicodeString& currentArrayElements, int currentArrayId);
-		void remapFSListHeads(int addr);
+    icu::UnicodeString xmiElementName2uimaTypeName(icu::UnicodeString& nameSpaceURI, icu::UnicodeString& localName);
+    int createByteArray(icu::UnicodeString& currentArrayElements, int currentArrayId);
+    void remapFSListHeads(int addr);
 
-		void tokenize(UnicodeString&, std::vector<std::string>&);
-		int createIntList(  std::vector<std::string>& featVal);
-		int createFloatList( std::vector<std::string>& featVal);
-		int createStringList(  std::vector<std::string>& featVal);
-		int createFSList(  std::vector<std::string>& featVal);
+    void tokenize(icu::UnicodeString&, std::vector<std::string>&);
+    int createIntList(  std::vector<std::string>& featVal);
+    int createFloatList( std::vector<std::string>& featVal);
+    int createStringList(  std::vector<std::string>& featVal);
+    int createFSList(  std::vector<std::string>& featVal);
+    
+    void addArrayElement(lowlevel::TyFS addr,lowlevel::TyFSType arrayType, 
+			 int arrayPos, std::string & buffer);
+    
+    void handleFeature(lowlevel::TyFS addr, icu::UnicodeString & featName,
+		       std::vector<std::string> & featVal);
+    
+    void handleFeature(lowlevel::TyFS addr, lowlevel::TyFSFeature featCode,
+		       lowlevel::TyFSType rangeTypeCode,std::vector<std::string> & featVal);
 
-		void addArrayElement(lowlevel::TyFS addr,lowlevel::TyFSType arrayType, 
-											int arrayPos, std::string & buffer);
+    int createArray(  lowlevel::TyFSType typeCode,
+		      std::vector<std::string>& featVal, int xmiID);
 
-		void handleFeature(lowlevel::TyFS addr, UnicodeString & featName,
-												std::vector<std::string> & featVal);
-
-		void handleFeature(lowlevel::TyFS addr, lowlevel::TyFSFeature featCode,
-								lowlevel::TyFSType rangeTypeCode,std::vector<std::string> & featVal);
-
-		int createArray(  lowlevel::TyFSType typeCode,
-								std::vector<std::string>& featVal, int xmiID);
-
-		void processView(int sofaXmiId, UnicodeString & membersString) ;
+    void processView(int sofaXmiId, icu::UnicodeString & membersString) ;
 		int getFsAddrForXmiId(int xmiId);
 		void addToOutOfTypeSystemData(XmlElementName * xmlElementName, const Attributes & attrs);
 		void addOutOfTypeSystemFeature(OotsElementData * ootsElem, 
-					UnicodeString & featName, std::vector<UnicodeString> & featVals);
+					icu::UnicodeString & featName, std::vector<icu::UnicodeString> & featVals);
 
 		// container for data shared between the XmiCasSerialier and
 		// XmiDeserializer, to support things such as consistency of IDs across
@@ -198,12 +198,12 @@ namespace uima {
 		std::vector<int> deserializedFsAddrs;
 
 		// map from namespace prefixes to URIs.
-		std::map<UnicodeString, UnicodeString> nsPrefixToUriMap;
+		std::map<icu::UnicodeString, icu::UnicodeString> nsPrefixToUriMap;
 		// map from xmi namespace  to uima namespace 
-		std::map<UnicodeString, UnicodeString> xmiNamespaceToUimaNamespaceMap;
+		std::map<icu::UnicodeString, icu::UnicodeString> xmiNamespaceToUimaNamespaceMap;
 
 		//typename - values
-		std::map<UnicodeString, std::vector<UnicodeString>* > multiValuedFeatures; 
+		std::map<icu::UnicodeString, std::vector<icu::UnicodeString>* > multiValuedFeatures; 
 		int ignoreDepth;
 
 		// The type of the most recently created FS. Needed for arrays, also
@@ -215,7 +215,7 @@ namespace uima {
 		// String arrays serialized with the values as child elements, we can't create
 		// the array until we've seen all of the child elements.
 		int currentArrayId;
-		UnicodeString currentArrayElements;
+		icu::UnicodeString currentArrayElements;
 
 		int nextSofaNum; //number of sofas found so far
 

--- a/src/cas/uima/xmishareddata.hpp
+++ b/src/cas/uima/xmishareddata.hpp
@@ -78,7 +78,7 @@ public:
  std::string name;
   std::string value;
   
-  XmlAttribute(UnicodeString name, UnicodeString value) {
+  XmlAttribute(icu::UnicodeString name, icu::UnicodeString value) {
     this->name = ((UnicodeStringRef)name).asUTF8();
     this->value = ((UnicodeStringRef)value).asUTF8();
   }
@@ -369,8 +369,8 @@ public:
     oed->attributes.push_back(new XmlAttribute(featName, featVal));
   }  
 
-  void addOutOfTypeSystemAttribute(int addr, UnicodeString& featName, 
-    UnicodeString & featVal) {
+  void addOutOfTypeSystemAttribute(int addr, icu::UnicodeString& featName, 
+				   icu::UnicodeString & featVal) {
       //cout << "addOotsAttribute " << featName << "=" << featVal << endl;
       addOutOfTypeSystemAttribute(addr, ( (UnicodeStringRef)featName).asUTF8(),
         ( (UnicodeStringRef)featVal).asUTF8());

--- a/src/cas/xcasdeserializer.cpp
+++ b/src/cas/xcasdeserializer.cpp
@@ -83,7 +83,7 @@ namespace uima {
 
   }
 
-  void XCASDeserializer::deserialize(UnicodeString & xcasFilename, CAS & cas) {
+  void XCASDeserializer::deserialize(icu::UnicodeString & xcasFilename, CAS & cas) {
     char buff[1024];
     xcasFilename.extract(0, xcasFilename.length(), buff);
 	XMLCh* native = XMLString::transcode(buff);

--- a/src/cas/xcasdeserializer_handler.cpp
+++ b/src/cas/xcasdeserializer_handler.cpp
@@ -55,6 +55,8 @@ using namespace std;
 #include "uima/resmgr.hpp"
 
 
+#define DEBUG 0
+
 namespace uima {
 
 // ---------------------------------------------------------------------------
@@ -67,7 +69,7 @@ namespace uima {
             //    ,iv_typesystem(iv_casimpl.getHeap().getTypeSystem())
                 ) {
 
-    //cout << " XCASDeserializerHandler::constructor " << endl;
+    if (DEBUG) std::cerr << " XCASDeserializerHandler::constructor " << std::endl;
     currentContentFeat.append(DEFAULT_CONTENT_FEATURE);
     sofaTypeCode = uima::internal::gs_tySofaType;
     FSIndexRepository * fsidx = &iv_cas->getBaseIndexRepository();
@@ -88,7 +90,7 @@ namespace uima {
   }
 
   XCASDeserializerHandler::~XCASDeserializerHandler()   {
-    //cout << " XCASDeserializerHandler::destructor " << endl;
+    if (DEBUG) std::cout << " XCASDeserializerHandler::destructor " << std::endl;
     for (size_t i = 0; i < fsTree.size(); i++) {
       FSInfo * fsinfo = (FSInfo*) fsTree[i];
       if (fsinfo != 0) {
@@ -117,12 +119,12 @@ namespace uima {
 // ---------------------------------------------------------------------------
 
   void  XCASDeserializerHandler::setDocumentLocator(const Locator* const locator) {
-    //cout << " XCASDeserializerHandler::setDocumentLocator() " << endl;
+    if (DEBUG) std::cerr << " XCASDeserializerHandler::setDocumentLocator() " << std::endl;
     iv_locator = locator;
   }
 
   void XCASDeserializerHandler::startDocument() {
-    //cout << " XCASDeserializerHandler::startDocument() " << endl;
+    if (DEBUG) cout << " XCASDeserializerHandler::startDocument() " << endl;
     iv_state = DOC_STATE;
   }
 
@@ -130,10 +132,10 @@ namespace uima {
       const   XMLCh* const    localname,
       const   XMLCh* const    qname,
       const Attributes & attrs) {
-    //cout << " XCASDeserializerHandler::startElement() " << UnicodeString((UChar*)qname, XMLString::stringLen(qname)) << endl;
+    if (DEBUG) std::cerr << " XCASDeserializerHandler::startElement() " << icu::UnicodeString((UChar*)qname, XMLString::stringLen(qname)) << endl;
     assert(sizeof(XMLCh) == sizeof(UChar));
 
-    UnicodeString qualifiedName( (UChar const *) qname, XMLString::stringLen(qname));
+    icu::UnicodeString qualifiedName( (UChar const *) qname, XMLString::stringLen(qname));
     buffer.remove();
 
     switch (iv_state) {
@@ -183,8 +185,8 @@ namespace uima {
 
   void XCASDeserializerHandler::characters(
     const   XMLCh* const  cpwsz,
-    const unsigned int    uiLength) {
-    //cout << "XCASDeserializerHandler::characters: \"" << icu::UnicodeString(cpwsz, uiLength) << "\"" << endl;
+    const XMLSize_t    uiLength) {
+    if (DEBUG) std::cerr << "XCASDeserializerHandler::characters: \"" << icu::UnicodeString(cpwsz, uiLength) << "\"" << endl;
 
     assert(sizeof(XMLCh) == sizeof(UChar));
 
@@ -204,8 +206,8 @@ namespace uima {
   void XCASDeserializerHandler::endElement(const XMLCh* const uri,
       const XMLCh* const localname,
       const XMLCh* const qname) {
-    //cout << " XCASDeserializerHandler::endElement() " << UnicodeString( (UChar*) qname, XMLString::stringLen(qname) ) << endl;
-    UnicodeString qualifiedName( (UChar const *) qname, XMLString::stringLen(qname));
+    if (DEBUG) std::cerr << " XCASDeserializerHandler::endElement() " << icu::UnicodeString( (UChar*) qname, XMLString::stringLen(qname) ) << " -- buffer is >" << buffer << "<" << endl;
+    icu::UnicodeString qualifiedName( (UChar const *) qname, XMLString::stringLen(qname));
     assert(sizeof(XMLCh) == sizeof(UChar));
     switch (iv_state) {
     case DOC_STATE: {
@@ -247,7 +249,7 @@ namespace uima {
     }
     case DOC_TEXT_STATE: {
       // Assume old style TCAS with one text Sofa
-      SofaFS newSofa = iv_cas->createInitialSofa(UnicodeString("text"));
+      SofaFS newSofa = iv_cas->createInitialSofa(icu::UnicodeString("text"));
       CAS* cas = iv_cas->getInitialView();
       cas->registerView(newSofa);
       // Set the document text without creating a documentAnnotation
@@ -308,8 +310,8 @@ namespace uima {
 
 
 // Create a new FS.
-  void XCASDeserializerHandler::readFS(UnicodeString & qualifiedName, const Attributes & attrs) {
-    UnicodeString typeName(qualifiedName);
+  void XCASDeserializerHandler::readFS(icu::UnicodeString & qualifiedName, const Attributes & attrs) {
+    icu::UnicodeString typeName(qualifiedName);
     Type type = iv_cas->getTypeSystem().getType(typeName);
     uima::lowlevel::TyFSType typecode =  uima::internal::FSPromoter::demoteType(type);
 
@@ -333,8 +335,8 @@ namespace uima {
     int id = -1;
 //       int sofaRef = -1; // 0 ==> baseCas indexRepository
     vector<int>* sofaRef = new vector<int>;
-    UnicodeString attrName;
-    UnicodeString attrValue;
+    icu::UnicodeString attrName;
+    icu::UnicodeString attrValue;
     bool nameMapping = false;
     UChar ubuff[256];
     UErrorCode errorCode = U_ZERO_ERROR;
@@ -347,12 +349,12 @@ namespace uima {
 
       // determine if this is the one and only initial view Sofa
       bool isInitialView = false;
-      int extsz = UnicodeString(CAS::FEATURE_BASE_NAME_SOFAID).extract(ubuff, 256, errorCode);
+      int extsz = icu::UnicodeString(CAS::FEATURE_BASE_NAME_SOFAID).extract(ubuff, 256, errorCode);
       if (extsz > 256) {
         cout << "ACK!" << endl;
       }
       const UChar* sofaID = attrs.getValue(ubuff);
-      if (0==UnicodeStringRef(sofaID).compare(UnicodeString("_DefaultTextSofaName"))) {
+      if (0==UnicodeStringRef(sofaID).compare(icu::UnicodeString("_DefaultTextSofaName"))) {
         sofaID = ubuff;
       }
 //   no Sofa mapping for now
@@ -360,11 +362,11 @@ namespace uima {
 //           // Map incoming SofaIDs
 //           sofaID = iv_ctx->mapToSofaID(sofaID).getSofaId();
 //         }
-      if (0==UnicodeStringRef(sofaID).compare(UnicodeString(CAS::NAME_DEFAULT_SOFA))) {
+      if (0==UnicodeStringRef(sofaID).compare(icu::UnicodeString(CAS::NAME_DEFAULT_SOFA))) {
         isInitialView = true;
       }
       // get the sofaNum
-      extsz = UnicodeString(CAS::FEATURE_BASE_NAME_SOFANUM).extract(ubuff, 256, errorCode);
+      extsz = icu::UnicodeString(CAS::FEATURE_BASE_NAME_SOFANUM).extract(ubuff, 256, errorCode);
       if (extsz > 256) {
         cout << "ACK!" << endl;
       }
@@ -372,7 +374,7 @@ namespace uima {
       int thisSofaNum = atoi(UnicodeStringRef(aString).asUTF8().c_str());
 
       // get the sofa's FeatureStructure id
-      UnicodeString(ID_ATTR_NAME).extract(ubuff,256, errorCode);
+      icu::UnicodeString(ID_ATTR_NAME).extract(ubuff,256, errorCode);
       aString = attrs.getValue(ubuff);
       int sofaFsId = atoi(UnicodeStringRef(aString).asUTF8().c_str());
 
@@ -509,8 +511,8 @@ namespace uima {
     vector<int>* indexRep = new vector<int>;
     int id = -1;
     int size=0;
-    UnicodeString attrName;
-    UnicodeString attrValue;
+    icu::UnicodeString attrName;
+    icu::UnicodeString attrValue;
 
     for (size_t i = 0; i < attrs.getLength(); i++) {
       assertWithMsg( sizeof(XMLCh) == sizeof(UChar), "Port required!");
@@ -566,7 +568,7 @@ namespace uima {
 
   }
 
-  void XCASDeserializerHandler::readArrayElement(UnicodeString & qualifiedName, const Attributes & attrs) {
+  void XCASDeserializerHandler::readArrayElement(icu::UnicodeString & qualifiedName, const Attributes & attrs) {
     if (qualifiedName.compare(ARRAY_ELEMENT_TAG) != 0) {
       ErrorInfo errInfo;
       errInfo.setErrorId((TyErrorId)UIMA_ERR_RESOURCE_CORRUPTED);
@@ -592,8 +594,8 @@ namespace uima {
     iv_state = ARRAY_ELE_CONTENT_STATE;
   }
 
-  void XCASDeserializerHandler::addArrayElement(UnicodeString & buffer) {
-
+  void XCASDeserializerHandler::addArrayElement(icu::UnicodeString & buffer) {
+ 
     if (arrayPos >= iv_casimpl.getHeap().getArraySize(currentAddr) ) {
       ErrorInfo errInfo;
       errInfo.setErrorId((TyErrorId)UIMA_ERR_RESOURCE_CORRUPTED);
@@ -622,7 +624,7 @@ namespace uima {
         break;
       }
     case internal::gs_tyStringArrayType: {
-        //add the striug
+        //add the string
         int stringoffset = iv_cas->getHeap()->addString(buffer);
         //set the array value in fs heap
         lowlevel::TyFS  stringref =  iv_cas->getHeap()->getStringAsFS(stringoffset);
@@ -693,13 +695,14 @@ namespace uima {
 
 
   // Create a feature value from a string representation.
-  void XCASDeserializerHandler::handleFeature(lowlevel::TyFS addr, UnicodeString & featName, UnicodeString & featVal, bool lenient) {
+  void XCASDeserializerHandler::handleFeature(lowlevel::TyFS addr, icu::UnicodeString & featName, icu::UnicodeString & featVal, bool lenient) {
+
     lowlevel::TyFSType fstype = iv_casimpl.getHeap().getType(addr);
     Type type = uima::internal::FSPromoter::promoteType(fstype, iv_cas->getTypeSystem().getLowlevelTypeSystem());
     handleFeature(type, addr, featName, featVal, lenient);
   }
 
-  void XCASDeserializerHandler::handleFeature(Type & type, lowlevel::TyFS addr, UnicodeString & featName, UnicodeString & featVal,
+  void XCASDeserializerHandler::handleFeature(Type & type, lowlevel::TyFS addr, icu::UnicodeString & featName, icu::UnicodeString & featVal,
       bool lenient) {
     char charFeatVal[10];
 
@@ -709,7 +712,7 @@ namespace uima {
         iv_typesystem->subsumes(internal::gs_tyAnnotationBaseType, fstype)) {
       int ifeatval = atoi(UnicodeStringRef(featVal).asUTF8().c_str());
       sprintf(charFeatVal, "%d", sofaRefMap[ifeatval]);
-      featVal.setTo(UnicodeString(charFeatVal));
+      featVal.setTo(icu::UnicodeString(charFeatVal));
     }
 
     // handle v1.x sofanum values, remapping so that _InitialView always == 1
@@ -719,7 +722,7 @@ namespace uima {
       iv_casimpl.getHeap().setIntValue(addr, internal::gs_tySofaNumFeature, indexMap[sofaNum]);
     }
 
-    UnicodeString prefix(REF_PREFIX);
+    icu::UnicodeString prefix(REF_PREFIX);
     if (featName.startsWith(REF_PREFIX)) {
       featName.remove(0,prefix.length());             // Delete prefix
     }

--- a/src/cas/xmideserializer.cpp
+++ b/src/cas/xmideserializer.cpp
@@ -83,7 +83,7 @@ namespace uima {
 
   }
 
-  void XmiDeserializer::deserialize(UnicodeString & xmiFilename, CAS & cas, bool lenient) {
+  void XmiDeserializer::deserialize(icu::UnicodeString & xmiFilename, CAS & cas, bool lenient) {
     char buff[1024];
     xmiFilename.extract(0, xmiFilename.length(), buff);
     XMLCh* native = XMLString::transcode(buff);
@@ -311,7 +311,7 @@ namespace uima {
 
  }
 
- void XmiDeserializer::deserialize(UnicodeString & xmiFilename, 
+  void XmiDeserializer::deserialize(icu::UnicodeString & xmiFilename, 
 									CAS & cas,
 									XmiSerializationSharedData & sharedData) {
     char buff[1024];

--- a/src/cas/xmideserializer_handler.cpp
+++ b/src/cas/xmideserializer_handler.cpp
@@ -119,8 +119,8 @@ namespace uima {
 		const   XMLCh* const    localname,
 		const   XMLCh* const    qname,
 		const Attributes & attrs) {
-			//cout << " XmiDeserializerHandler::startElement() qname " << UnicodeString((UChar*)qname, XMLString::stringLen(qname)) << endl;
-			//cout << "startElement localname " << UnicodeString(localname) << " uri " << UnicodeString(uri) << endl;
+			//cout << " XmiDeserializerHandler::startElement() qname " << icu::UnicodeString((UChar*)qname, XMLString::stringLen(qname)) << endl;
+			//cout << "startElement localname " << icu::UnicodeString(localname) << " uri " << icu::UnicodeString(uri) << endl;
 			//cout << "startElement attrs " << attrs.getLength() << endl;
 
 
@@ -137,12 +137,12 @@ namespace uima {
 			// resolve the prefixes even with a non-namespace-aware parser
 			if (attrs.getLength() != 0) {
 				for (size_t i = 0; i < attrs.getLength(); i++) {
-					UnicodeString attrName(attrs.getQName(i));
+					icu::UnicodeString attrName(attrs.getQName(i));
 					//cout << "xmlns attrName " << attrName << endl;
 					if (attrName.indexOf("xmlns:") > -1 ) {
-						UnicodeString prefix;
+						icu::UnicodeString prefix;
 						attrName.extract(6, attrName.length()-6, prefix);
-						UnicodeString uri(attrs.getValue(i));
+						icu::UnicodeString uri(attrs.getValue(i));
 						nsPrefixToUriMap[prefix]= uri;
 					}
 				}
@@ -158,16 +158,16 @@ namespace uima {
 				return;
 			}
 
-			UnicodeString unsuri(uri);
-			UnicodeString ulocalname(localname);
+			icu::UnicodeString unsuri(uri);
+			icu::UnicodeString ulocalname(localname);
 			// parser not namespace-enabled, so try to resolve NS ourselves
 			// TODO test with non namespace-enabled
 			/**
 			int colonIndex = qualifiedName.indexOf(":");
 			if (colonIndex != -1) {
-			UnicodeString prefix;
+			icu::UnicodeString prefix;
 			qualifiedName.extract(0, colonIndex,prefix);
-			map<UnicodeString,UnicodeString>::iterator uriite = nsPrefixToUriMap.find(prefix);
+			map<icu::UnicodeString,icu::UnicodeString>::iterator uriite = nsPrefixToUriMap.find(prefix);
 			if (uriite != nsPrefixToUriMap.end()) { 
 			nameSpaceURI = uriite->second;
 			} else {
@@ -186,7 +186,7 @@ namespace uima {
 			//readFS(typeName, attrs);
 			readFS(unsuri, ulocalname, qualifiedName, attrs);
 
-			map<UnicodeString, vector<UnicodeString>*>::iterator mite;
+			map<icu::UnicodeString, vector<icu::UnicodeString>*>::iterator mite;
             for (mite=multiValuedFeatures.begin();
 				mite != multiValuedFeatures.end(); mite++) {
 					if (mite->second != NULL) {
@@ -222,7 +222,7 @@ namespace uima {
 
 	void XmiDeserializerHandler::characters(
 					const   XMLCh* const  cpwsz,
-					const unsigned int    uiLength) {
+					const XMLSize_t    uiLength) {
 		assert(sizeof(XMLCh) == sizeof(UChar));
 
 		if (this->iv_state == FEAT_CONTENT_STATE) {
@@ -243,13 +243,13 @@ namespace uima {
 						const XMLCh* const qname) {
 		/**
 		cout << " XmiDeserializerHandler::endElement() qname " 
-		<< UnicodeString( (UChar*) qname, XMLString::stringLen(qname) ) << endl;
+		<< icu::UnicodeString( (UChar*) qname, XMLString::stringLen(qname) ) << endl;
 		cout << " XmiDeserializerHandler::endElement() uri " 
-		<< UnicodeString( (UChar*) nsuri, XMLString::stringLen(nsuri) ) << endl;
+		<< icu::UnicodeString( (UChar*) nsuri, XMLString::stringLen(nsuri) ) << endl;
 		**/
 
 		assert(sizeof(XMLCh) == sizeof(UChar));
-		UnicodeString qualifiedName( (UChar const *) qname, XMLString::stringLen(qname));
+		icu::UnicodeString qualifiedName( (UChar const *) qname, XMLString::stringLen(qname));
 		//cout << "endElement qualifiedname " << qualifiedName << endl;
 		switch (iv_state) {
 		case DOC_STATE: {
@@ -264,11 +264,11 @@ namespace uima {
 			// We have just processed one of possibly many values for a feature.
 			// Store this value in the multiValuedFeatures map for later use.
 			//cout << "endELement FEAT_CONTENT_STATE " << buffer << endl;
-			map<UnicodeString, vector<UnicodeString>*>::iterator ite =
+			map<icu::UnicodeString, vector<icu::UnicodeString>*>::iterator ite =
 				multiValuedFeatures.find(qualifiedName);
-			vector<UnicodeString> * valuesList=0; 
+			vector<icu::UnicodeString> * valuesList=0; 
 			if (ite == multiValuedFeatures.end()) {
-				valuesList = new vector<UnicodeString>;
+				valuesList = new vector<icu::UnicodeString>;
 				multiValuedFeatures[qualifiedName] = valuesList;
 			} else {
 				valuesList = ite->second;
@@ -287,10 +287,10 @@ namespace uima {
 			// encoded as subelements
 			if (this->outOfTypeSystemElement != NULL) {
 				if (this->multiValuedFeatures.size() > 0) {
-					map<UnicodeString,vector<UnicodeString>*>::iterator ite;
+					map<icu::UnicodeString,vector<icu::UnicodeString>*>::iterator ite;
 					for (ite=multiValuedFeatures.begin(); ite != multiValuedFeatures.end();ite++) {
-						UnicodeString featName = ite->first;
-						vector<UnicodeString>* featVals = ite->second;
+						icu::UnicodeString featName = ite->first;
+						vector<icu::UnicodeString>* featVals = ite->second;
 						addOutOfTypeSystemFeature(outOfTypeSystemElement, featName, *featVals);
 					}
 				}
@@ -312,10 +312,10 @@ namespace uima {
 						//	    currentArrayElements.length() << endl;
 						if (currentArrayElements.length()==0) // were not specified as attributes
 						{
-							map<UnicodeString, vector<UnicodeString>*>::iterator ite =
-								multiValuedFeatures.find(UnicodeString("elements"));
+							map<icu::UnicodeString, vector<icu::UnicodeString>*>::iterator ite =
+								multiValuedFeatures.find(icu::UnicodeString("elements"));
 							if (ite != multiValuedFeatures.end()) {
-								vector<UnicodeString>* vals = ite->second;
+								vector<icu::UnicodeString>* vals = ite->second;
 								for (size_t i=0; i<vals->size(); i++) {
 									featVals.push_back( ((UnicodeStringRef)vals->at(i)).asUTF8()); 
 								}
@@ -325,10 +325,10 @@ namespace uima {
 						}         
 						createArray(internal::FSPromoter::demoteType(currentType), featVals, currentArrayId);
 					} else {
-						map<UnicodeString,vector<UnicodeString>*>::iterator ite;
+						map<icu::UnicodeString,vector<icu::UnicodeString>*>::iterator ite;
 						for (ite=multiValuedFeatures.begin(); ite != multiValuedFeatures.end();ite++) {
-							UnicodeString featName = ite->first;
-							vector<UnicodeString>* featVals = ite->second;
+							icu::UnicodeString featName = ite->first;
+							vector<icu::UnicodeString>* featVals = ite->second;
 							vector<string> stringList;
 							for (size_t i=0; i< featVals->size();i++) {
 								stringList.push_back( ((UnicodeStringRef)featVals->at(i)).asUTF8());
@@ -388,10 +388,10 @@ namespace uima {
    * Converts an XMI element name to a UIMA-style dotted type name.
    * 
    */
-	UnicodeString XmiDeserializerHandler::xmiElementName2uimaTypeName(UnicodeString& nsUri, UnicodeString& localName) {
+	icu::UnicodeString XmiDeserializerHandler::xmiElementName2uimaTypeName(icu::UnicodeString& nsUri, icu::UnicodeString& localName) {
 		// check map first to see if we've already computed the namespace mapping
-		map<UnicodeString,UnicodeString>::iterator ite = xmiNamespaceToUimaNamespaceMap.find(nsUri);
-		UnicodeString uimaNamespace;
+		map<icu::UnicodeString,icu::UnicodeString>::iterator ite = xmiNamespaceToUimaNamespaceMap.find(nsUri);
+		icu::UnicodeString uimaNamespace;
 		if (ite != xmiNamespaceToUimaNamespaceMap.end()) {
 			uimaNamespace = ite->second;
 		} else {
@@ -417,26 +417,26 @@ namespace uima {
 
 
 // Create a new FS.
-	void XmiDeserializerHandler::readFS(UnicodeString & nsUri, UnicodeString & localName,
-		UnicodeString & qualifiedName, const Attributes & attrs) {
-			UnicodeString typeName = xmiElementName2uimaTypeName(nsUri, localName);
+	void XmiDeserializerHandler::readFS(icu::UnicodeString & nsUri, icu::UnicodeString & localName,
+		icu::UnicodeString & qualifiedName, const Attributes & attrs) {
+			icu::UnicodeString typeName = xmiElementName2uimaTypeName(nsUri, localName);
 			Type type = iv_cas->getTypeSystem().getType(typeName);
 			currentType=type;
 			
 			if (!type.isValid()) {
-				if (typeName.compare(UnicodeString("uima.cas.NULL"))==0) {
+				if (typeName.compare(icu::UnicodeString("uima.cas.NULL"))==0) {
 					//cout << "readFS ignore " << typeName << endl;
 					return; //ignore
 				}
-				if (typeName.compare(UnicodeString("uima.cas.View"))==0) {
+				if (typeName.compare(icu::UnicodeString("uima.cas.View"))==0) {
 					//cout << "readFS  " << typeName << endl;
-					UnicodeString attrName; 
+					icu::UnicodeString attrName; 
 					int sofaXmiId=0;
-					UnicodeString members;
+					icu::UnicodeString members;
 					for (size_t i = 0; i < attrs.getLength(); i++) {
 						attrName =  attrs.getQName(i);
 						if (attrName.compare(CAS::FEATURE_BASE_NAME_SOFA) == 0) {
-							UnicodeString ustr(attrs.getValue(i));
+							icu::UnicodeString ustr(attrs.getValue(i));
 							sofaXmiId = atoi( ((UnicodeStringRef)ustr).asUTF8().c_str());
 						} else if (attrName.compare("members") == 0) {
 							members = attrs.getValue(i);
@@ -465,13 +465,13 @@ namespace uima {
 				}
 			} else if (iv_cas->getTypeSystem().isArrayType(internal::FSPromoter::demoteType(type)) ) {
 				
-        UnicodeString attrName; 
+        icu::UnicodeString attrName; 
 				int xmiId=0;
-				UnicodeString elements;
+				icu::UnicodeString elements;
 				for (size_t i = 0; i < attrs.getLength(); i++) {
 						attrName =  attrs.getQName(i);
 						if (attrName.compare(XMI_ID_ATTR_NAME) == 0) {
-							UnicodeString ustr(attrs.getValue(i));
+							icu::UnicodeString ustr(attrs.getValue(i));
 							currentArrayId = atoi( ((UnicodeStringRef)ustr).asUTF8().c_str());
 						} else if (attrName.compare("elements") == 0) {
 							currentArrayElements = attrs.getValue(i);
@@ -503,7 +503,7 @@ namespace uima {
 	*          whitespace-separated string of FS addresses. Each FS is to be added to the specified
 	*          sofa's index repository
 	*/
-	void XmiDeserializerHandler::processView(int sofaXmiId, UnicodeString & members) {
+	void XmiDeserializerHandler::processView(int sofaXmiId, icu::UnicodeString & members) {
 		// TODO: this requires View to come AFTER all of its members
 		//cout << "processView start " << sofaXmiId << "members=" << membersString << endl;
 		if (members.length() > 0) { 
@@ -544,7 +544,7 @@ namespace uima {
 	}
 
 
-	int XmiDeserializerHandler::createByteArray(UnicodeString& currentArrayElements, int currentArrayId) {
+	int XmiDeserializerHandler::createByteArray(icu::UnicodeString& currentArrayElements, int currentArrayId) {
 		string elemStr = ( (UnicodeStringRef) currentArrayElements).asUTF8();
 		int arrayLen = elemStr.length() / 2;
 		ByteArrayFS fs = iv_cas->createByteArrayFS(arrayLen);
@@ -579,8 +579,8 @@ namespace uima {
 		int id = -1;
 		//       int sofaRef = -1; // 0 ==> baseCas indexRepository
 		////vector<int>* sofaRef = new vector<int>;
-		UnicodeString attrName;
-		UnicodeString attrValue;
+		icu::UnicodeString attrName;
+		icu::UnicodeString attrValue;
 		bool nameMapping = false;
 		UChar ubuff[256];
 		UErrorCode errorCode = U_ZERO_ERROR;
@@ -589,16 +589,16 @@ namespace uima {
 
 
 		if (sofaTypeCode == heapValue) {
-			int extsz = UnicodeString(CAS::FEATURE_BASE_NAME_SOFAID).extract(ubuff, 256, errorCode);
+			int extsz = icu::UnicodeString(CAS::FEATURE_BASE_NAME_SOFAID).extract(ubuff, 256, errorCode);
 			if (extsz > 256) {
 				cout << "ACK!" << endl;
 			}
 			const UChar* sofaID = attrs.getValue(ubuff);
 
-			if (0==UnicodeStringRef(sofaID).compare(UnicodeString("_DefaultTextSofaName"))) {  
+			if (0==UnicodeStringRef(sofaID).compare(icu::UnicodeString("_DefaultTextSofaName"))) {  
 				// initial view Sofa always has sofaNum = 1
 				thisSofaNum = 1;
-			} else if (0==UnicodeStringRef(sofaID).compare(UnicodeString(CAS::NAME_DEFAULT_SOFA))) {   
+			} else if (0==UnicodeStringRef(sofaID).compare(icu::UnicodeString(CAS::NAME_DEFAULT_SOFA))) {   
 				thisSofaNum = 1;
 			}  else {
 				thisSofaNum = this->nextSofaNum++;
@@ -611,20 +611,20 @@ namespace uima {
 			attrName = (UChar*)attrs.getQName(i);
 			attrValue = (UChar*)attrs.getValue(i);
 
-			if (attrName.compare(UnicodeString(XMI_ID_ATTR_NAME)) == 0) {
+			if (attrName.compare(icu::UnicodeString(XMI_ID_ATTR_NAME)) == 0) {
 				id = atoi(UnicodeStringRef(attrValue).asUTF8().c_str());
 				//cout << "got " << XMI_ID_ATTR_NAME << " " << id << endl;
 			} else {       
 				if (sofaTypeCode == heapValue && attrName.compare(CAS::FEATURE_BASE_NAME_SOFAID)==0) {
-					if (attrValue.compare(UnicodeString("_DefaultTextSofaName"))==0 ) {
+					if (attrValue.compare(icu::UnicodeString("_DefaultTextSofaName"))==0 ) {
 						// First change old default Sofa name into the new one
-						attrValue = UnicodeString(CAS::NAME_DEFAULT_SOFA);
+						attrValue = icu::UnicodeString(CAS::NAME_DEFAULT_SOFA);
 					}
 				} else if (sofaTypeCode == heapValue 
-					&& attrName.compare(UnicodeString(CAS::FEATURE_BASE_NAME_SOFANUM))==0) {
+					&& attrName.compare(icu::UnicodeString(CAS::FEATURE_BASE_NAME_SOFANUM))==0) {
 						stringstream str;
 						str << thisSofaNum << endl;
-						attrValue = UnicodeString(str.str().c_str());
+						attrValue = icu::UnicodeString(str.str().c_str());
 					}
 					//cout << "readFS calling handleFeature " << attrName << " attrvalue= "
 					//	<< attrValue << endl;
@@ -696,7 +696,7 @@ namespace uima {
     case internal::gs_tyStringArrayType: {
         //add the striug
 				StringArrayFS strFS(fs);
-				UnicodeString strval(buffer.c_str());
+				icu::UnicodeString strval(buffer.c_str());
 				strFS.set( (size_t) arrayPos,strval);
 				break;
     }
@@ -760,7 +760,7 @@ namespace uima {
 
 
 	// Create a feature value from a string representation.
-	void XmiDeserializerHandler::handleFeature(lowlevel::TyFS addr, UnicodeString & featName, UnicodeString & featVal, bool lenient) {
+	void XmiDeserializerHandler::handleFeature(lowlevel::TyFS addr, icu::UnicodeString & featName, icu::UnicodeString & featVal, bool lenient) {
 		lowlevel::TyFSType fstype = iv_casimpl.getHeap().getType(addr);
 		Type type = uima::internal::FSPromoter::promoteType(fstype, iv_cas->getTypeSystem().getLowlevelTypeSystem());
 		Feature feat = type.getFeatureByBaseName(featName);
@@ -790,7 +790,7 @@ namespace uima {
   void XmiDeserializerHandler::handleFeature(Type & type, 
     lowlevel::TyFS addr,
     lowlevel::TyFSFeature featCode, 
-    UnicodeString & featVal,
+    icu::UnicodeString & featVal,
     bool lenient) {
 
     FeatureStructure fs = uima::internal::FSPromoter::promoteFS(addr, *iv_cas);
@@ -965,7 +965,7 @@ namespace uima {
   }
  
   void XmiDeserializerHandler::handleFeature(lowlevel::TyFS addr, 
-                          UnicodeString & featName,
+                          icu::UnicodeString & featName,
                           vector<string> & featVal) {
     lowlevel::TyFSType fstype = iv_casimpl.getHeap().getType(addr);
     Type type = uima::internal::FSPromoter::promoteType(fstype, iv_cas->getTypeSystem().getLowlevelTypeSystem());
@@ -1046,7 +1046,7 @@ void XmiDeserializerHandler::handleFeature(lowlevel::TyFS addr,
 		   } else {
 			   Type type = internal::FSPromoter::promoteType(rangeTypeCode,
 				   iv_cas->getTypeSystem().getLowlevelTypeSystem());
-				 UnicodeString val(featVals.at(0).c_str());
+				 icu::UnicodeString val(featVals.at(0).c_str());
 			   handleFeature(type,		   
 				   addr, featCode,val, true);
 		   }
@@ -1055,7 +1055,7 @@ void XmiDeserializerHandler::handleFeature(lowlevel::TyFS addr,
 	  }
   }
 
-  void XmiDeserializerHandler::tokenize(UnicodeString & ustr, vector<string> & stringList ) {
+  void XmiDeserializerHandler::tokenize(icu::UnicodeString & ustr, vector<string> & stringList ) {
 
 	  string str = (UnicodeStringRef(ustr)).asUTF8();
 	  string::size_type lastPos = str.find_first_not_of(" ", 0); 
@@ -1156,7 +1156,7 @@ void XmiDeserializerHandler::handleFeature(lowlevel::TyFS addr,
   int XmiDeserializerHandler::createStringList(vector<string>& stringList)	{   
     StringListFS listFS =   iv_cas->createStringListFS();
     for (size_t i = 0; i < stringList.size(); i++ ) {
-      UnicodeString value(stringList.at(i).c_str()); //use xmiId to look up addr
+      icu::UnicodeString value(stringList.at(i).c_str()); //use xmiId to look up addr
 	    listFS.addLast(value);
     }
 	  return internal::FSPromoter::demoteFS(listFS);
@@ -1318,12 +1318,12 @@ void XmiDeserializerHandler::handleFeature(lowlevel::TyFS addr,
     this->outOfTypeSystemElement = new OotsElementData();
     //this->outOfTypeSystemElement->elementName = xmlElementName->qualifiedName;
 	  this->outOfTypeSystemElement->elementName = xmlElementName;
-    UnicodeString attrName;
-	  UnicodeString attrValue;
+    icu::UnicodeString attrName;
+	  icu::UnicodeString attrValue;
     for (size_t i = 0; i < attrs.getLength(); i++) {
       attrName = attrs.getQName(i);
       attrValue = attrs.getValue(i);
-      if (attrName.compare(UnicodeString(XMI_ID_ATTR_NAME))==0) {
+      if (attrName.compare(icu::UnicodeString(XMI_ID_ATTR_NAME))==0) {
 		    UnicodeStringRef uref(attrValue);
         this->outOfTypeSystemElement->xmiId = atoi(uref.asUTF8().c_str());
       }
@@ -1342,8 +1342,8 @@ void XmiDeserializerHandler::handleFeature(lowlevel::TyFS addr,
      * @param featVals feature values, as a list of strings
      */
   void XmiDeserializerHandler::addOutOfTypeSystemFeature(OotsElementData * ootsElem, 
-		UnicodeString & featName, 
-		vector<UnicodeString> & featVals) {
+		icu::UnicodeString & featName, 
+		vector<icu::UnicodeString> & featVals) {
 	  vector<string> * pVals = new vector<string>;
     for (size_t i=0;i<featVals.size();i++) {
 		  pVals->push_back(  ((UnicodeStringRef)featVals.at(i)).asUTF8());    

--- a/src/cas/xmiwriter.cpp
+++ b/src/cas/xmiwriter.cpp
@@ -298,7 +298,7 @@ namespace uima {
  }
 
  void XmiWriter::writeView(ostream & os,int sofaXmiId, vector<lowlevel::TyFS>& members) {
-   UnicodeString viewType(UnicodeString("uima.cas.View"));
+   icu::UnicodeString viewType(icu::UnicodeString("uima.cas.View"));
    UnicodeStringRef uref(viewType.getBuffer(), viewType.length());
    XmlElementName * elemName = uimaTypeName2XmiElementName(uref);
 
@@ -548,7 +548,7 @@ namespace uima {
       case internal::gs_tyStringArrayType: {
         StringArrayFS arrayfs(fs);
         size_t n = arrayfs.size();
-         UnicodeString ustr;       
+	icu::UnicodeString ustr;       
         for (size_t i=0; i < n;i++) {
           ustr.setTo("");
           normalize( arrayfs.get(i), ustr );
@@ -1153,7 +1153,7 @@ void XmiWriter::write(ostream & os) {
                                     }
     case internal::gs_tyNEStringListType:  {
       StringListFS curNode(fs);
-      UnicodeString ustr;
+      icu::UnicodeString ustr;
       while (!curNode.isEmpty()) { 
         ///string head = curNode.getHead().asUTF8();
         ustr.setTo("");

--- a/src/cas/xmlerror_handler.cpp
+++ b/src/cas/xmlerror_handler.cpp
@@ -66,7 +66,7 @@ namespace uima {
     msg.addParam( (UChar const *) e.getSystemId());
     msg.addParam(e.getLineNumber());
 	msg.addParam(e.getColumnNumber());
-	msg.addParam(UnicodeString(e.getMessage(),XMLString::stringLen(e.getMessage())));
+	msg.addParam(icu::UnicodeString(e.getMessage(),XMLString::stringLen(e.getMessage())));
     errInfo.setMessage(msg);
     errInfo.setSeverity(ErrorInfo::unrecoverable);
     ExcIllFormedInputError exc(errInfo);
@@ -81,7 +81,7 @@ namespace uima {
     msg.addParam( (UChar const *) e.getSystemId());
     msg.addParam(e.getLineNumber());
     msg.addParam(e.getColumnNumber());
-	msg.addParam(UnicodeString(e.getMessage(),XMLString::stringLen(e.getMessage())));
+    msg.addParam(icu::UnicodeString(e.getMessage(),XMLString::stringLen(e.getMessage())));
     errInfo.setMessage(msg);
     errInfo.setSeverity(ErrorInfo::unrecoverable);
     ExcIllFormedInputError exc(errInfo);
@@ -96,7 +96,7 @@ namespace uima {
     msg.addParam( (UChar const *) e.getSystemId());
     msg.addParam(e.getLineNumber());
     msg.addParam(e.getColumnNumber());
-	msg.addParam(UnicodeString(e.getMessage(),XMLString::stringLen(e.getMessage())));
+    msg.addParam(icu::UnicodeString(e.getMessage(),XMLString::stringLen(e.getMessage())));
     errInfo.setMessage(msg);
     errInfo.setSeverity(ErrorInfo::unrecoverable);
     ExcIllFormedInputError exc(errInfo);

--- a/src/cas/xmltypesystemreader.cpp
+++ b/src/cas/xmltypesystemreader.cpp
@@ -103,10 +103,10 @@ namespace uima {
     return gs_tempXMLChBuffer;
   }
 
-  UnicodeString convert( XMLCh const * cpUCBuf ) {
+  icu::UnicodeString convert( XMLCh const * cpUCBuf ) {
     assertWithMsg( sizeof(XMLCh) == sizeof(UChar), "Port required!");
     unsigned int uiLen = XMLString::stringLen( cpUCBuf );
-    return UnicodeString( (UChar const *) cpUCBuf, uiLen);
+    return icu::UnicodeString( (UChar const *) cpUCBuf, uiLen);
   }
 
 

--- a/src/cas/xmlwriter.cpp
+++ b/src/cas/xmlwriter.cpp
@@ -334,7 +334,7 @@ namespace uima {
 
       uima::lowlevel::TyFSType tyIndexType = indexDef.getTypeForIndex(crIndexID);
       lowlevel::IndexABase const & crIndex = crIxRep.getLowlevelIndex(crIndexID, tyIndexType);
-      auto_ptr<uima::lowlevel::IndexIterator> pIterator(crIndex.createIterator());
+      unique_ptr<uima::lowlevel::IndexIterator> pIterator(crIndex.createIterator());
       for (pIterator->moveToFirst(); pIterator->isValid(); pIterator->moveToNext()) {
         lowlevel::TyFS tyFS = pIterator->get();
         writeFS(0, os, tyFS);
@@ -487,7 +487,7 @@ namespace uima {
 
 	void XCASWriter::writeStringArray(ostream & os, StringArrayFS const & array, char const * tag) {
     size_t i;
-		UnicodeString ustr;
+    icu::UnicodeString ustr;
     if (array.size() > 0) {
       os << " size=\"" << array.size() << "\">" << endl;
       for (i=0; i<array.size(); ++i) {

--- a/src/framework/consoleui.cpp
+++ b/src/framework/consoleui.cpp
@@ -61,7 +61,7 @@ namespace uima {
                          const char * cpszTitle, const char * cpszCopyright)
         : iv_bQuiet(false),
         iv_cpszHelp(NULL),
-        iv_szProcessName(""),
+	iv_szProcessName(strdup("")),
         iv_currentArg(99999) {
       // Catch any APR errors here in case caller does not expect this constructor to fail
       try {

--- a/src/framework/dottypesystemwriter.cpp
+++ b/src/framework/dottypesystemwriter.cpp
@@ -76,7 +76,7 @@ namespace uima {
   }
 
   UnicodeStringRef adjustTypeName(UnicodeStringRef ulstrName) {
-    UnicodeString ustrTypePfx( "uima" );                         // Our namespace
+    icu::UnicodeString ustrTypePfx( "uima" );                         // Our namespace
     ustrTypePfx.append( (UChar) uima::TypeSystem::NAMESPACE_SEPARATOR );
     if (u_strncmp(ulstrName.getBuffer(), ustrTypePfx.getBuffer(), min(ulstrName.length(), ustrTypePfx.length())) == 0) {
       ulstrName = UnicodeStringRef(ulstrName.getBuffer() + ustrTypePfx.length(),

--- a/src/framework/internal_jedii_engine.cpp
+++ b/src/framework/internal_jedii_engine.cpp
@@ -554,10 +554,10 @@ namespace uima {
         // create and initialize Java VM
         char * optionStrings[] = {
                                    cpBuf.get(),
-                                   "-Xmx256MB",
+                                   strdup("-Xmx256MB"),
 #ifndef NDEBUG
-                                   "-Xcheck:jni",
-                                   "-Xcheck:nabounds",
+                                   strdup("-Xcheck:jni"),
+                                   strdup("-Xcheck:nabounds"),
 #endif
                                  };
 

--- a/src/framework/resmgr.cpp
+++ b/src/framework/resmgr.cpp
@@ -682,7 +682,7 @@ namespace uima {
       } 
 
       //instantiate framework logger
-      cv_pclSingletonInstance->iv_frameworkLogger = new LogFacility(UnicodeString("org.apache.uima.cpp"), cv_pclSingletonInstance->iv_logLevel);
+      cv_pclSingletonInstance->iv_frameworkLogger = new LogFacility(icu::UnicodeString("org.apache.uima.cpp"), cv_pclSingletonInstance->iv_logLevel);
 
       cv_pclSingletonInstance->iv_frameworkLogger->logMessage("ResourceManager Instance created.");
     } // release mutex

--- a/src/framework/taespecifier.cpp
+++ b/src/framework/taespecifier.cpp
@@ -990,7 +990,7 @@ namespace uima {
 
 
 
-  void AnalysisEngineDescription::appendConfigParamsAndSettingsToXMLBuffer(UnicodeString & s) const  {
+  void AnalysisEngineDescription::appendConfigParamsAndSettingsToXMLBuffer(icu::UnicodeString & s) const  {
 
 
     AnalysisEngineMetaData const & md = * getAnalysisEngineMetaData();
@@ -1200,7 +1200,7 @@ namespace uima {
     ///AnalysisEngineMetaData const & md = * getAnalysisEngineMetaData();
     
     //    name
-    UnicodeString out;
+    icu::UnicodeString out;
     s.append("<name>");
     XMLWriterABase::normalize(UnicodeStringRef(md.getName()), out);
     s.append(out);

--- a/src/framework/taespecifierbuilder.cpp
+++ b/src/framework/taespecifierbuilder.cpp
@@ -951,7 +951,7 @@ namespace uima {
               continue;
             }
             bool takesMemoryOwnerShip;
-            auto_ptr<TypeDescription> desc( buildTypeDesc((DOMElement *) typeDescs->item(i)) );
+            unique_ptr<TypeDescription> desc( buildTypeDesc((DOMElement *) typeDescs->item(i)) );
             typeSystemDesc.addTypeDescription(desc.get(), takesMemoryOwnerShip);
             if (takesMemoryOwnerShip) {
               desc.release();
@@ -960,7 +960,7 @@ namespace uima {
         }
       } else if (childTag.compare(TAG_IMPORT_DESC) == 0) {
         bool takesMemoryOwnerShip;
-        auto_ptr<ImportDescription> desc( buildImportDesc((DOMElement *) children->item(j)) );
+        unique_ptr<ImportDescription> desc( buildImportDesc((DOMElement *) children->item(j)) );
         typeSystemDesc.addImportDescription(desc.get(), takesMemoryOwnerShip);
         if (takesMemoryOwnerShip) {
           desc.release();
@@ -974,7 +974,7 @@ namespace uima {
               continue;
             }
             bool takesMemoryOwnerShip;
-            auto_ptr<ImportDescription> desc( buildImportDesc((DOMElement *) importDescs->item(i)) );
+            unique_ptr<ImportDescription> desc( buildImportDesc((DOMElement *) importDescs->item(i)) );
             typeSystemDesc.addImportDescription(desc.get(), takesMemoryOwnerShip);
             if (takesMemoryOwnerShip) {
               desc.release();
@@ -1043,7 +1043,7 @@ namespace uima {
             if ((features->item(j))->getNodeType() != DOMNode::ELEMENT_NODE) {
               continue;
             }
-            auto_ptr<FeatureDescription> desc( buildFeatureDesc((DOMElement *) features->item(j)) );
+            unique_ptr<FeatureDescription> desc( buildFeatureDesc((DOMElement *) features->item(j)) );
             bool takesMemoryOwnership;
             typeDesc->addFeatureDescription(desc.get(), takesMemoryOwnership);
             if (takesMemoryOwnership) {
@@ -1059,7 +1059,7 @@ namespace uima {
             if ((allowedVals->item(j))->getNodeType() != DOMNode::ELEMENT_NODE) {
               continue;
             }
-            auto_ptr<AllowedValue> desc( buildAllowedValue((DOMElement *) allowedVals->item(j)) );
+            unique_ptr<AllowedValue> desc( buildAllowedValue((DOMElement *) allowedVals->item(j)) );
             bool takesMemoryOwnership;
             typeDesc->addAllowedValue(desc.get(), takesMemoryOwnership);
             if (takesMemoryOwnership) {
@@ -1213,12 +1213,12 @@ namespace uima {
             if ((importDescs->item(j))->getNodeType() != DOMNode::ELEMENT_NODE) {
               continue;
             }
-            UnicodeString location = convert(((DOMElement *) importDescs->item(j))->getAttribute(convert(ATTR_IMPORT_DESC_LOCATION)));
+	    icu::UnicodeString location = convert(((DOMElement *) importDescs->item(j))->getAttribute(convert(ATTR_IMPORT_DESC_LOCATION)));
             if (location.length() > 0)
               buildTypePriorityFromImportLocation(aeMetaData, location, xmlFileLoc, alreadyImportedLocations);
             else {
               //throw exception if import location not specified
-              UnicodeString name = convert(((DOMElement *) importDescs->item(j))->getAttribute(convert(ATTR_IMPORT_DESC_NAME)));
+	      icu::UnicodeString name = convert(((DOMElement *) importDescs->item(j))->getAttribute(convert(ATTR_IMPORT_DESC_NAME)));
               //throw exception if import location not set.
               ErrorMessage errMsg = ErrorMessage(UIMA_MSG_ID_EXC_UNSUPPORTED_XML_ATTRIBUTE);
               errMsg.addParam(xmlFileLoc);
@@ -1338,7 +1338,7 @@ namespace uima {
   void XMLParser::buildFSIndexCollection(AnalysisEngineMetaData & aeMetaData,
       DOMElement * descElem,
       vector<icu::UnicodeString> & alreadyImportedLocations,
-      UnicodeString const & lastFileName) {
+      icu::UnicodeString const & lastFileName) {
 
     assert(EXISTS(descElem));
     assert( XMLString::compareString(descElem->getNodeName(), convert(TAG_FS_INDEX_COLLECTION)) == 0
@@ -1367,14 +1367,14 @@ namespace uima {
             if ((importDescs->item(j))->getNodeType() != DOMNode::ELEMENT_NODE) {
               continue;
             }
-            UnicodeString loc = convert(((DOMElement *) importDescs->item(j))->getAttribute(convert(ATTR_IMPORT_DESC_LOCATION)));
+	    icu::UnicodeString loc = convert(((DOMElement *) importDescs->item(j))->getAttribute(convert(ATTR_IMPORT_DESC_LOCATION)));
             if (loc.length() > 0) {
               buildFSIndexFromImportLocation(aeMetaData,
                                              loc,
                                              alreadyImportedLocations,
                                              lastFileName);
             } else {
-              UnicodeString name = convert(((DOMElement *) importDescs->item(j))->getAttribute(convert(ATTR_IMPORT_DESC_NAME)));
+	      icu::UnicodeString name = convert(((DOMElement *) importDescs->item(j))->getAttribute(convert(ATTR_IMPORT_DESC_NAME)));
               //throw exception if import location not set.
               ErrorMessage errMsg = ErrorMessage(UIMA_MSG_ID_EXC_UNSUPPORTED_XML_ATTRIBUTE);
               errMsg.addParam(lastFileName);
@@ -1608,7 +1608,7 @@ namespace uima {
                   const TypeDescription::TyVecpFeatureDescriptions & featDescs = cpTypeDesc->getFeatureDescriptions();
                   TypeDescription::TyVecpFeatureDescriptions::const_iterator ite;
                   for (ite = featDescs.begin(); ite != featDescs.end(); ite++) {
-                    UnicodeString featName(typeName);
+		    icu::UnicodeString featName(typeName);
                     featName += UIMA_TYPE_FEATURE_SEPARATOR;
                     featName += (*ite)->getName();
                     capability->addCapabilityFeature(featName, typeStyle);
@@ -1849,7 +1849,7 @@ void XMLParser::buildFSIndexFromImportLocation(AnalysisEngineMetaData& fsDesc,
       vector<icu::UnicodeString> & alreadyImportedLocations,
       icu::UnicodeString const & lastFileName) {
 
-    UnicodeString importfn = ResourceManager::resolveFilename(fileName, lastFileName);
+    icu::UnicodeString importfn = ResourceManager::resolveFilename(fileName, lastFileName);
 
     for (size_t i=0; i < alreadyImportedLocations.size() ;i++) {
       if (importfn.compare(alreadyImportedLocations[i]) == 0 )  {
@@ -1931,7 +1931,7 @@ void XMLParser::buildFSIndexFromImportLocation(AnalysisEngineMetaData& fsDesc,
 
 
 
-    UnicodeString importfn = ResourceManager::resolveFilename(fileName, lastFileName);
+    icu::UnicodeString importfn = ResourceManager::resolveFilename(fileName, lastFileName);
 
     for (size_t i=0; i < alreadyImportedLocations.size(); i++) {
       if (importfn.compare(alreadyImportedLocations[i]) == 0 )  {
@@ -2224,11 +2224,11 @@ void XMLParser::buildFSIndexFromImportLocation(AnalysisEngineMetaData& fsDesc,
     return gs_tempXMLChBuffer;
   }
 
-  UnicodeString XMLParser::convert( XMLCh const * cpUCBuf ) const {
+  icu::UnicodeString XMLParser::convert( XMLCh const * cpUCBuf ) const {
     assertWithMsg( sizeof(XMLCh) == sizeof(UChar), "Port required!");
     if (EXISTS(cpUCBuf)) {
       unsigned int uiLen = XMLString::stringLen( cpUCBuf );
-      return UnicodeString( (UChar const *) cpUCBuf, uiLen);
+      return icu::UnicodeString( (UChar const *) cpUCBuf, uiLen);
     } else {
       return "";
     }

--- a/src/framework/typesystemdescription.cpp
+++ b/src/framework/typesystemdescription.cpp
@@ -44,7 +44,7 @@ namespace uima {
     TyVecpFeatureDescriptions::iterator ite;
     for (ite = otherDescs.begin(); ite != otherDescs.end(); ite++) {
       bool takesMemoryOwnership;
-      auto_ptr<FeatureDescription> desc ( new FeatureDescription(**ite) );
+      unique_ptr<FeatureDescription> desc ( new FeatureDescription(**ite) );
       addFeatureDescription(desc.get(), takesMemoryOwnership);
       if (takesMemoryOwnership) {
         desc.release();
@@ -55,7 +55,7 @@ namespace uima {
     TyVecpAllowedValues::iterator ite1;
     for (ite1 = otherAllowedValues.begin(); ite1 != otherAllowedValues.end(); ite1++) {
       bool takesMemoryOwnership;
-      auto_ptr<AllowedValue> allowedval ( new AllowedValue(**ite1) );
+      unique_ptr<AllowedValue> allowedval ( new AllowedValue(**ite1) );
       addAllowedValue(allowedval.get(), takesMemoryOwnership);
       if (takesMemoryOwnership) {
         allowedval.release();
@@ -219,7 +219,7 @@ namespace uima {
       //we do not handle import by 'name' which requires looking into
       //classpath and needs to be handle in Java.
       if (pImport->getLocation().length() > 0) {
-        const UnicodeString & fileLocation = pImport->findAbsoluteUrl(iv_xmlFileLoc);
+        const icu::UnicodeString & fileLocation = pImport->findAbsoluteUrl(iv_xmlFileLoc);
         //check it is not in already Imported list
 		bool needsToBeResolved=true;
         for (size_t j=0; j < alreadyImportedTypeSystemLocations.size() ;j++) {

--- a/src/framework/uima/stltools.hpp
+++ b/src/framework/uima/stltools.hpp
@@ -41,38 +41,43 @@
 
 
 #include <iostream>
+#include <iterator>
 #include <vector>
 #include <algorithm>
 #include <map>
 #include <string>
 #include <utility>
-#if defined( UIMA_NO_HASH_CONTAINERS_SUPPORTED ) || defined( UIMA_DONT_USE_HASH_CONTAINERS )
-// we include the appropriate headers
-#  include <set>
-#  include <map>
-#else
-#  if defined(__GNUC__)
-#define GCC_VERSION (__GNUC__ * 10000 \
-                     + __GNUC_MINOR__ * 100 \
-                     + __GNUC_PATCHLEVEL__)
-#     if (__GNUC__ >= 3)
-#        include <ext/hash_set>
-#        include <ext/hash_map>
-#        if (__GNUC_MINOR__ > 0)
-#        endif
-#     else   // gcc 2.9
-#        include <hash_set>
-#        include <hash_map>
-#     endif
-#  elif defined(__INTEL_COMPILER)
-#     define _HAS_TRADITIONAL_STL 1
-#     include <hash_set>
-#     include <hash_map>
-#  else
-#     include <hashset>
-#     include <hashmap>
-#  endif
-#endif
+
+#include <set>
+#include <map>
+
+// #if defined( UIMA_NO_HASH_CONTAINERS_SUPPORTED ) || defined( UIMA_DONT_USE_HASH_CONTAINERS )
+// // we include the appropriate headers
+// #  include <set>
+// #  include <map>
+// #else
+// #  if defined(__GNUC__)
+// #define GCC_VERSION (__GNUC__ * 10000 \
+//                      + __GNUC_MINOR__ * 100 \
+//                      + __GNUC_PATCHLEVEL__)
+// #     if (__GNUC__ >= 3)
+// #        include <ext/hash_set>
+// #        include <ext/hash_map>
+// #        if (__GNUC_MINOR__ > 0)
+// #        endif
+// #     else   // gcc 2.9
+// #        include <hash_set>
+// #        include <hash_map>
+// #     endif
+// #  elif defined(__INTEL_COMPILER)
+// #     define _HAS_TRADITIONAL_STL 1
+// #     include <hash_set>
+// #     include <hash_map>
+// #  else
+// #     include <hashset>
+// #     include <hashmap>
+// #  endif
+// #endif
 
 namespace uima {
 

--- a/src/framework/uima/strtools.hpp
+++ b/src/framework/uima/strtools.hpp
@@ -728,13 +728,15 @@ namespace uima {
     CharT  value;
     while (true) {  //lint !e716: while(1) ...
       i >> value;
-      if (!i.operator void*())
+      // It appears this is just checking if it's null and not null and
+      // not fail -- if (!i.operator void*())
+      if (i.fail())
         break;
       if (!strchr_templ(delimiters, value)) {
         s += value;
         while (true) {  //lint !e716: while(1) ...
           i >> value;
-          if (!i.operator void*())
+          if (i.fail())
             break;
           if (!strchr_templ(delimiters, value)) {
             s += value;

--- a/src/framework/uima/taespecifier.hpp
+++ b/src/framework/uima/taespecifier.hpp
@@ -1112,7 +1112,7 @@ namespace uima {
 	void toXMLBuffer(AnalysisEngineMetaData const & md,  
 													   bool isCasConsumer,
 													   icu::UnicodeString & s) const;
-    void appendConfigParamsAndSettingsToXMLBuffer(UnicodeString & s) const;
+	void appendConfigParamsAndSettingsToXMLBuffer(icu::UnicodeString & s) const;
 
     TyErrorId setFrameworkImplName(EnFrameworkImplName impl) {
       if (! isModifiable()) {

--- a/src/framework/uima/unistrref.hpp
+++ b/src/framework/uima/unistrref.hpp
@@ -1178,7 +1178,7 @@ namespace uima {
      */
     inline void extract(int32_t start,
                         int32_t length,
-                        UnicodeString& dst) const;
+                        icu::UnicodeString& dst) const;
 
     /**
      * Copy the characters in the range [<tt>start</tt>, <tt>limit</tt>)
@@ -1191,7 +1191,7 @@ namespace uima {
      */
     inline void extractBetween(int32_t start,
                                int32_t limit,
-                               UnicodeString& dst) const;
+                               icu::UnicodeString& dst) const;
 
     /* Substring extraction with conversion */
 
@@ -1378,7 +1378,7 @@ namespace uima {
      * @return a reference to this
      * @stable
      */
-    inline UnicodeStringRef& setTo(const UnicodeString& srcText);
+  inline UnicodeStringRef& setTo(const icu::UnicodeString& srcText);
 
     /**
      * Set the characters in the UnicodeString object to the characters
@@ -1456,7 +1456,7 @@ namespace uima {
                           int32_t dstStart) const;
     inline void doExtract(int32_t start,
                           int32_t length,
-                          UnicodeString& dst) const;
+                          icu::UnicodeString& dst) const;
 
     inline void
     pinIndices(int32_t& start,
@@ -2074,7 +2074,7 @@ namespace uima {
   inline void
   UnicodeStringRef::extract(int32_t start,
                             int32_t length,
-                            UnicodeString& target) const {
+                            icu::UnicodeString& target) const {
     target.replace(0, target.length(), getBuffer(), start, length);
   }
 // Replaces all of target by substring of src
@@ -2091,7 +2091,7 @@ namespace uima {
   inline void
   UnicodeStringRef::extractBetween(int32_t start,
                                    int32_t limit,
-                                   UnicodeString& dst) const {
+                                   icu::UnicodeString& dst) const {
     extract(start, limit - start, dst);
   }
 
@@ -2188,7 +2188,7 @@ namespace uima {
     return (*this);
   }
 
-  inline UnicodeStringRef& UnicodeStringRef::setTo(const UnicodeString& srcText) {
+  inline UnicodeStringRef& UnicodeStringRef::setTo(const icu::UnicodeString& srcText) {
     iv_pUChars  = srcText.getBuffer();
     iv_uiLength = srcText.length();
     return (*this);

--- a/src/jni/jni.cpp
+++ b/src/jni/jni.cpp
@@ -194,10 +194,10 @@ using namespace std;
         str << lUserCode << " " << message;
       }
       
-      UnicodeString msg(str.str().c_str());
+      icu::UnicodeString msg(str.str().c_str());
       // Convert the std::strings to Unicode using the default converter
-      UnicodeString ustrsource(classname.c_str(), classname.length());
-      UnicodeString ustrmethod(methodname.c_str(), methodname.length());
+      icu::UnicodeString ustrsource(classname.c_str(), classname.length());
+      icu::UnicodeString ustrmethod(methodname.c_str(), methodname.length());
       jstring jsrcclass = jnienv->NewString((jchar const *) ustrsource.getBuffer(), ustrsource.length());
       jstring jsrcmethod = jnienv->NewString((jchar const *) ustrmethod.getBuffer(), ustrmethod.length());
       jstring jmessage = jnienv->NewString((jchar const *) msg.getBuffer(), msg.length());
@@ -742,7 +742,7 @@ JNIEXPORT void JNICALL JAVA_PREFIX(processJNI) (JNIEnv* jeEnv,
       uima::SofaID sofaid;
       uima::UnicodeStringRef ref = usSofaName.toUStrPtrLenPair();
       icu::UnicodeString usofa = icu::UnicodeString( ref.getBuffer(), ref.length() );
-      sofaid.setSofaId( UnicodeString(usofa) );
+      sofaid.setSofaId( icu::UnicodeString(usofa) );
       sofaid.setComponentSofaName(usofa);
       tcas = cas.getView(cas.getSofa(sofaid));
       ///tyErrorId = ((uima::AnalysisEngine*) pEngine)->process(*tcas);

--- a/src/jni/jni_utils.cpp
+++ b/src/jni/jni_utils.cpp
@@ -231,7 +231,7 @@ void JNIUtils::createStringVector(JNIEnv* jeEnv, jobjectArray joArray, vector<ui
       JNIUString uString(jeEnv, js);
       uima::UnicodeStringRef ref = uString.toUStrPtrLenPair();
 //         cout << __FILE__ << __LINE__ << ":" << i << "  string " << uString.toUStrPtrLenPair() << endl;
-      rStringPool[i] = UnicodeString( ref.getBuffer(), ref.length() );
+      rStringPool[i] = icu::UnicodeString( ref.getBuffer(), ref.length() );
       rResult[i] = uima::UnicodeStringRef(rStringPool[i]);
     } else {
       rResult[i] = uima::UnicodeStringRef();

--- a/src/test/src/SimpleTextSegmenter.cpp
+++ b/src/test/src/SimpleTextSegmenter.cpp
@@ -36,7 +36,7 @@ private:
   size_t delimLen;
   size_t remainingLen;
 
-  UnicodeString delimUS;
+  icu::UnicodeString delimUS;
   const UChar * delimP;
   const UChar * docTextBeginP;
   const UChar * remainingTextP;
@@ -74,7 +74,7 @@ public:
     delimUS = "\n";
 
     /* read in configuration parameter setting */
-    UnicodeString param("SegmentDelimiter");
+    icu::UnicodeString param("SegmentDelimiter");
     if (rclAnnotatorContext.isParameterDefined(param) ) {
       rclAnnotatorContext.extractValue(param, delimUS);
     }

--- a/src/test/src/annotator_dump.cpp
+++ b/src/test/src/annotator_dump.cpp
@@ -274,7 +274,7 @@ AnnotatorDump::process(CAS & tcas,
     assert(false);
   }
   assert( EXISTS(writer) );
-  auto_ptr<CASWriterABase> apWriter( writer );
+  unique_ptr<CASWriterABase> apWriter( writer );
   apWriter->write(iv_clOutputStream);
 
   // in append mode all data in a session/collection is dumped into one file

--- a/src/test/src/test_cas.cpp
+++ b/src/test/src/test_cas.cpp
@@ -660,7 +660,7 @@ struct StrLemma {
 };
 
 
-void checkForwardOrder(lowlevel::FSHeap const & heap, auto_ptr<uima::lowlevel::IndexIterator> & it, uima::lowlevel::IndexComparator const * cpComp, vector<lowlevel::TyFS> const & fsVec) {
+void checkForwardOrder(lowlevel::FSHeap const & heap, unique_ptr<uima::lowlevel::IndexIterator> & it, uima::lowlevel::IndexComparator const * cpComp, vector<lowlevel::TyFS> const & fsVec) {
   size_t i=0;
   vector<lowlevel::TyFS> retrievedFSs;
   for (it->moveToFirst(); it->isValid(); it->moveToNext()) {
@@ -683,7 +683,7 @@ void checkForwardOrder(lowlevel::FSHeap const & heap, auto_ptr<uima::lowlevel::I
 }
 
 
-void checkReverseOrder(lowlevel::FSHeap const & heap,auto_ptr<uima::lowlevel::IndexIterator> & it, uima::lowlevel::IndexComparator const * cpComp, vector<lowlevel::TyFS> const & fsVec) {
+void checkReverseOrder(lowlevel::FSHeap const & heap,unique_ptr<uima::lowlevel::IndexIterator> & it, uima::lowlevel::IndexComparator const * cpComp, vector<lowlevel::TyFS> const & fsVec) {
   size_t i=0;
   vector<lowlevel::TyFS> retrievedFSs;
   for (it->moveToLast(); it->isValid(); it->moveToPrevious()) {
@@ -702,7 +702,7 @@ void checkReverseOrder(lowlevel::FSHeap const & heap,auto_ptr<uima::lowlevel::In
 
 }
 
-void checkPreviousNextMovements(auto_ptr<uima::lowlevel::IndexIterator> & it, uima::lowlevel::IndexComparator const * cpComp, vector<lowlevel::TyFS> const & fsVec) {
+void checkPreviousNextMovements(unique_ptr<uima::lowlevel::IndexIterator> & it, uima::lowlevel::IndexComparator const * cpComp, vector<lowlevel::TyFS> const & fsVec) {
   size_t i=0;
   vector<lowlevel::TyFS> retrievedFSs;
   for (it->moveToLast(); it->isValid(); it->moveToPrevious()) {
@@ -746,7 +746,7 @@ void checkOrderedIndex(uima::lowlevel::IndexABase const & ixBase, vector<lowleve
 
   }
   ASSERT_OR_THROWEXCEPTION( EXISTS(cpComp) );
-  auto_ptr<lowlevel::IndexIterator> it(ixBase.createIterator());
+  unique_ptr<lowlevel::IndexIterator> it(ixBase.createIterator());
 
   LOG("checking forward order");
   checkForwardOrder(heap, it, cpComp, fsVec);
@@ -772,7 +772,7 @@ void checkSetIndex(lowlevel::IndexABase const & ix, size_t num) {
   LOG("Checking set index");
   LOG("Index size: " << ix.getSize() );
   vector<lowlevel::TyFS> retrievedFSs;
-  auto_ptr<lowlevel::IndexIterator> it(ix.createIterator());
+  unique_ptr<lowlevel::IndexIterator> it(ix.createIterator());
   for (it->moveToFirst(); it->isValid(); it->moveToNext()) {
     retrievedFSs.push_back(it->get());
   }
@@ -1003,7 +1003,7 @@ void testLowLevelIndex() {
   LOG("Lemmas in index:");
   {
     i=0;
-    auto_ptr<uima::lowlevel::IndexIterator> it( ixStore.getLowlevelIndex(SETIX, lemmaType).createIterator() );
+    unique_ptr<uima::lowlevel::IndexIterator> it( ixStore.getLowlevelIndex(SETIX, lemmaType).createIterator() );
     for (it->moveToFirst(); it->isValid(); it->moveToNext() ) {
       LOG(" lemma number: " << i);
       uima::lowlevel::TyFS lemma = it->get();
@@ -1076,7 +1076,7 @@ void testLowLevelIndex() {
   // 4. test delete index
   icu::UnicodeString anIxID = tcasimpl.getAnnotationIndexID();
   ixStore.remove(tokens[0]);
-  auto_ptr<lowlevel::IndexIterator> it( ixStore.getLowlevelIndex( anIxID, tokenAnnotType).createIterator() );
+  unique_ptr<lowlevel::IndexIterator> it( ixStore.getLowlevelIndex( anIxID, tokenAnnotType).createIterator() );
 
   it->moveToFirst();
   ASSERT_OR_THROWEXCEPTION( it->get() != tokens[0]);
@@ -1749,8 +1749,8 @@ void testIteratorSetToPosition() {
 
   lowlevel::IndexABase const & ix = indexRep.getLowlevelIndex(ixID, tokenType);
 
-  auto_ptr<lowlevel::IndexIterator> it1(ix.createIterator() );
-  auto_ptr<lowlevel::IndexIterator> it2(ix.createIterator());
+  unique_ptr<lowlevel::IndexIterator> it1(ix.createIterator() );
+  unique_ptr<lowlevel::IndexIterator> it2(ix.createIterator());
 
   const size_t numberOfAdvances = 2;
   it1->moveToFirst();

--- a/src/test/src/test_casserializer.cpp
+++ b/src/test/src/test_casserializer.cpp
@@ -107,8 +107,8 @@ void testSerializeDefinitions(util::ConsoleUI * pConsole) {
 
   /* create engine */
   ErrorInfo errInfo;
-  UnicodeString filename("toktest.xml");
-  UnicodeString fn = ResourceManager::resolveFilename(filename, filename);
+  icu::UnicodeString filename("toktest.xml");
+  icu::UnicodeString fn = ResourceManager::resolveFilename(filename, filename);
 
   uima::TextAnalysisEngine * pEngine = TextAnalysisEngine::createTextAnalysisEngine
                                        (UnicodeStringRef(fn).asUTF8().c_str(), errInfo);
@@ -202,8 +202,8 @@ void testSerializeData(util::ConsoleUI * pConsole ) {
   uima::Timer iv_serializeTimerData;
 
   ErrorInfo errInfo;
-  UnicodeString filename("toktest.xml");
-  UnicodeString fn = ResourceManager::resolveFilename(filename, filename);
+  icu::UnicodeString filename("toktest.xml");
+  icu::UnicodeString fn = ResourceManager::resolveFilename(filename, filename);
 
   uima::TextAnalysisEngine * pEngine =
     TextAnalysisEngine::createTextAnalysisEngine(UnicodeStringRef(fn).asUTF8().c_str(), errInfo);
@@ -215,8 +215,8 @@ void testSerializeData(util::ConsoleUI * pConsole ) {
   ASSERT_OR_THROWEXCEPTION( errInfo.getErrorId() == UIMA_ERR_NONE );
 
   /* read in a file */
-  UnicodeString dataFile("tdoc_001_en_850.asc");
-  UnicodeString datafn = ResourceManager::resolveFilename(dataFile, dataFile);
+  icu::UnicodeString dataFile("tdoc_001_en_850.asc");
+  icu::UnicodeString datafn = ResourceManager::resolveFilename(dataFile, dataFile);
   std::string dataFilename = UnicodeStringRef(datafn).asUTF8();
   /* open file for read */
   FILE * pFile = fopen( dataFilename.c_str(),"rb");
@@ -234,7 +234,7 @@ void testSerializeData(util::ConsoleUI * pConsole ) {
   fclose(pFile);
 
   /* convert to unicode and set tcas document text*/
-  UnicodeString ustrInputText(pBuffer, (int32_t)numread, "utf-8");
+  icu::UnicodeString ustrInputText(pBuffer, (int32_t)numread, "utf-8");
   delete[] pBuffer;
 
   /* set TCAS Document text */

--- a/src/test/src/test_engine.cpp
+++ b/src/test/src/test_engine.cpp
@@ -157,13 +157,13 @@ void testCallingSequence1(uima::util::ConsoleUI & rclConsole, const TCHAR * cpsz
 //   UnicodeStringRef uRef(us);
   rclConsole.formatHeader(_TEXT("testing Engine CallingSequence1"));
 
-  cas->setDocumentText(us.getBuffer(), us.length());
+  cas->setDocumentText(us.getBuffer(), us.length(), true);
   cas->getDocumentAnnotation().setLanguage("en");
   failIfNotTrue(pEngine->process(*cas) == UIMA_ERR_NONE);
   failIfNotTrue(cas->reset() == UIMA_ERR_NONE);
   failIfNotTrue(pEngine->destroy() == UIMA_ERR_NONE);
 
-  cas->setDocumentText(us.getBuffer(), us.length());
+  cas->setDocumentText(us.getBuffer(), us.length(), true);
   cas->getDocumentAnnotation().setLanguage("en");
   failIfNotTrue(pEngine->process(*cas) == UIMA_ERR_ENGINE_INVALID_CALLING_SEQUENCE);
 
@@ -217,14 +217,14 @@ void testCallingSequence3(uima::util::ConsoleUI & rclConsole, const TCHAR * cpsz
   /* test for NULL ptrs */
 
   UnicodeStringRef uref2(NULL);
-  cas->setDocumentText(uref2.getBuffer(), uref2.length());
+  cas->setDocumentText(uref2.getBuffer(), uref2.length(), true);
   cas->getDocumentAnnotation().setLanguage("en");
   failIfNotTrue(pEngine->process(*cas) == UIMA_ERR_NONE);
   failIfNotTrue(cas->reset() == UIMA_ERR_NONE);
 
 
   /* test for subsequent processes */
-  cas->setDocumentText(uref2.getBuffer(), uref2.length());
+  cas->setDocumentText(uref2.getBuffer(), uref2.length(), true);
   cas->getDocumentAnnotation().setLanguage("en");
 
   failIfNotTrue(pEngine->process(*cas) == UIMA_ERR_NONE);
@@ -334,8 +334,8 @@ void testProcessDocu(uima::util::ConsoleUI & rclConsole,
   for (rclConsole.setToFirst(); rclConsole.isValid(); rclConsole.setToNext()) {
     ////uima::util::Filename     clInputFilename(rclConsole.getAsCString());
     //replaced with a hard wired data file
-    UnicodeString filename("tdoc_001_enus_850.asc");
-    UnicodeString fn = ResourceManager::resolveFilename(filename, filename);
+	  icu::UnicodeString filename("tdoc_001_enus_850.asc");
+	  icu::UnicodeString fn = ResourceManager::resolveFilename(filename, filename);
     uima::util::Filename clInputFilename(UnicodeStringRef(fn).asUTF8().c_str());
 
     size_t                  uiSize;
@@ -362,7 +362,7 @@ void testProcessDocu(uima::util::ConsoleUI & rclConsole,
 ///      failIfNotTrue(rclEngine.addDocPart(ustrInputFileContent) == UIMA_ERR_ENGINE_INVALID_CALLING_SEQUENCE);
 ///      failIfNotTrue(rclEngine.addDoc(ustrInputFileContent) == UIMA_ERR_ENGINE_INVALID_CALLING_SEQUENCE);
 
-    cas->setDocumentText(docBuffer.getDocBuffer(), docBuffer.getLength() );
+    cas->setDocumentText(docBuffer.getDocBuffer(), docBuffer.getLength(), true );
     cas->getDocumentAnnotation().setLanguage(crclLanguage);
 
     utErrorId = rclEngine.process(*cas);
@@ -405,7 +405,7 @@ void testProcessTerm(uima::util::ConsoleUI & rclConsole,
 
   // For terms we always add a term annotation for the whole "document"
   /* since we already added a complete doc, we may not add anything else */
-  cas->setDocumentText(docBuffer.getDocBuffer(), docBuffer.getLength() );
+  cas->setDocumentText(docBuffer.getDocBuffer(), docBuffer.getLength(), true );
   cas->getDocumentAnnotation().setLanguage(crclLanguage);
 
   utErrorId = rclEngine.process(*cas);
@@ -488,8 +488,8 @@ void testCasMultiplier(uima::util::ConsoleUI & rclConsole)
 
   ErrorInfo errInfo;
 
-  UnicodeString filename("SimpleTextSegmenter.xml");
-  UnicodeString fn = ResourceManager::resolveFilename(filename, filename);
+  icu::UnicodeString filename("SimpleTextSegmenter.xml");
+  icu::UnicodeString fn = ResourceManager::resolveFilename(filename, filename);
   pEngine = TextAnalysisEngine::createTextAnalysisEngine(UnicodeStringRef(fn).asUTF8().c_str(), errInfo );
   failIfNotTrue(errInfo.getErrorId() == UIMA_ERR_NONE);
   failIfNotTrue(pEngine != NULL);
@@ -502,7 +502,7 @@ void testCasMultiplier(uima::util::ConsoleUI & rclConsole)
 
  
   CAS * cas = pEngine->newCAS();
-  cas->setDocumentText(UnicodeString("This is the first sentence. This is the second sentence. This is the third sentence."));
+  cas->setDocumentText(icu::UnicodeString("This is the first sentence. This is the second sentence. This is the third sentence."));
 
   CASIterator iter = pEngine->processAndOutputNewCASes(*cas);
   int num=0;
@@ -577,8 +577,8 @@ int main(int argc, char * argv[]) /*
     /* test registering user specified loggers */
     testRegisterLoggers(clConsole);
     ///mainTest(clConsole, lCCSID, cpszConfigFilename, cpszLanguage, (size_t) lNumberOfIterations);
-    UnicodeString filename("toktest.xml");
-    UnicodeString fn = ResourceManager::resolveFilename(filename, filename);
+    icu::UnicodeString filename("toktest.xml");
+    icu::UnicodeString fn = ResourceManager::resolveFilename(filename, filename);
     UnicodeStringRef fnRef(fn);
     string fnStr = fnRef.asUTF8();
     mainTest(clConsole, cpszCCSID, fnStr.c_str(),

--- a/src/test/src/test_iterators.cpp
+++ b/src/test/src/test_iterators.cpp
@@ -551,8 +551,8 @@ void testSubIterators(util::ConsoleUI * pConsole) {
   pConsole->info("Testing SubIterators");
 
   ErrorInfo errInfo;
-  UnicodeString filename("toktest.xml");
-  UnicodeString fn = ResourceManager::resolveFilename(filename, filename);
+  icu::UnicodeString filename("toktest.xml");
+  icu::UnicodeString fn = ResourceManager::resolveFilename(filename, filename);
 
   /* create engine */
   uima::TextAnalysisEngine * pEngine =
@@ -564,8 +564,8 @@ void testSubIterators(util::ConsoleUI * pConsole) {
   ASSERT_OR_THROWEXCEPTION(EXISTS(pEngine));
   ASSERT_OR_THROWEXCEPTION( errInfo.getErrorId() == UIMA_ERR_NONE );
 
-  UnicodeString dataFile("tdoc_001_en_850.asc");
-  UnicodeString datafn = ResourceManager::resolveFilename(dataFile, dataFile);
+  icu::UnicodeString dataFile("tdoc_001_en_850.asc");
+  icu::UnicodeString datafn = ResourceManager::resolveFilename(dataFile, dataFile);
   std::string dataFilename = UnicodeStringRef(datafn).asUTF8();
   /* read in file contents and set TCAS Document text */
   FILE * pFile = fopen( dataFilename.c_str(),"rb");
@@ -583,7 +583,7 @@ void testSubIterators(util::ConsoleUI * pConsole) {
   fclose(pFile);
 
   /* convert to unicode and set tcas document text*/
-  UnicodeString ustrInputText(pBuffer, (int32_t)numread, "utf-8");
+  icu::UnicodeString ustrInputText(pBuffer, (int32_t)numread, "utf-8");
   delete[] pBuffer;
   /* set TCAS Document text */
   CAS * tcas = pEngine->newCAS();
@@ -618,8 +618,8 @@ void testIterators(util::ConsoleUI * pConsole) {
   pConsole->info("Testing Iterators");
 
   ErrorInfo errInfo;
-  UnicodeString filename("toktest.xml");
-  UnicodeString fn = ResourceManager::resolveFilename(filename, filename);
+  icu::UnicodeString filename("toktest.xml");
+  icu::UnicodeString fn = ResourceManager::resolveFilename(filename, filename);
 
   /* create engine */
   uima::TextAnalysisEngine * pEngine =
@@ -631,8 +631,8 @@ void testIterators(util::ConsoleUI * pConsole) {
   ASSERT_OR_THROWEXCEPTION(EXISTS(pEngine));
   ASSERT_OR_THROWEXCEPTION( errInfo.getErrorId() == UIMA_ERR_NONE );
 
-  UnicodeString dataFile("toktest.xml");
-  UnicodeString datafn = ResourceManager::resolveFilename(dataFile, dataFile);
+  icu::UnicodeString dataFile("toktest.xml");
+  icu::UnicodeString datafn = ResourceManager::resolveFilename(dataFile, dataFile);
   std::string dataFilename = UnicodeStringRef(datafn).asUTF8();
   /* read in file contents and set TCAS Document text */
   FILE * pFile = fopen( dataFilename.c_str(),"rb");
@@ -650,7 +650,7 @@ void testIterators(util::ConsoleUI * pConsole) {
   fclose(pFile);
 
   /* convert to unicode and set tcas document text*/
-  UnicodeString ustrInputText(pBuffer, (int32_t)numread, "utf-8");
+  icu::UnicodeString ustrInputText(pBuffer, (int32_t)numread, "utf-8");
   delete[] pBuffer;
   /* set TCAS Document text */
   CAS * tcas = pEngine->newCAS();
@@ -680,8 +680,8 @@ void testCaching(util::ConsoleUI * pConsole) {
   pConsole->info("Testing Caching");
 
   ErrorInfo errInfo;
-  UnicodeString filename("toktest.xml");
-  UnicodeString fn = ResourceManager::resolveFilename(filename, filename);
+  icu::UnicodeString filename("toktest.xml");
+  icu::UnicodeString fn = ResourceManager::resolveFilename(filename, filename);
 
   uima::TextAnalysisEngine * pEngine =
     TextAnalysisEngine::createTextAnalysisEngine(UnicodeStringRef(fn).asUTF8().c_str(), errInfo);
@@ -695,7 +695,7 @@ void testCaching(util::ConsoleUI * pConsole) {
   /* set TCAS Document text */
   CAS * tcas = pEngine->newCAS();
   ASSERT_OR_THROWEXCEPTION( EXISTS(tcas) );
-  UnicodeString ustrInputText("This is test doc for testing iteration.");
+  icu::UnicodeString ustrInputText("This is test doc for testing iteration.");
   tcas->setDocumentText(ustrInputText.getBuffer(), ustrInputText.length(), true);
   tcas->getDocumentAnnotation().setLanguage("en");
 

--- a/src/test/src/test_language.cpp
+++ b/src/test/src/test_language.cpp
@@ -86,7 +86,7 @@ void mainDisplay(util::ConsoleUI & rclConsole, Language & rclLang)
 }
 
 // Display an array of Unicode characters
-void ucharDisplay(util::ConsoleUI & rclConsole, char* tag, const UChar* ucbuff, int len) {
+void ucharDisplay(util::ConsoleUI & rclConsole, const char* tag, const UChar* ucbuff, int len) {
   char cbuf[1024];
   char* s = cbuf;
   *s++ = '\"';
@@ -184,8 +184,8 @@ mainTest(
   UErrorCode err;
   std::string ss;
 
-  char* cstr = "abcdefghijklmnopqrstuvyzyz 0123456789";
-  UnicodeString us1(cstr);
+  const char* cstr = "abcdefghijklmnopqrstuvyzyz 0123456789";
+  icu::UnicodeString us1(cstr);
   UnicodeStringRef usr(us1);
 
   // into std::string with default conversion
@@ -193,9 +193,9 @@ mainTest(
   if (bVerbose) rclConsole.format("extract to std::string",ss.c_str());
   ASSERT (strlen(cstr) == ss.length());
 
-  // substring into UnicodeString
-  UnicodeString us2("initialValue");
-  UnicodeString us3("z 0");
+  // substring into icu::UnicodeString
+  icu::UnicodeString us2("initialValue");
+  icu::UnicodeString us3("z 0");
   usr.extractBetween(25,28,us2);               // Should be "z 0"
   if (bVerbose) ucharDisplay(rclConsole, "extractBetween into UChar buffer", us2.getBuffer(), us2.length());
   ASSERT ( us2 == us3 );
@@ -205,7 +205,7 @@ mainTest(
   len = us1.extract(ucbuf,100,err);         // Pre-fill buffer
 
   usr.extract(27,3,ucbuf,5);                // extract part of USR into the buffer
-  UnicodeString us4("abcde012ijklm");
+  icu::UnicodeString us4("abcde012ijklm");
   if (bVerbose) ucharDisplay(rclConsole, "extract into UChar buffer", ucbuf, 13);
   ASSERT ( us4.compare(ucbuf,13) == 0 );
 
@@ -227,18 +227,18 @@ mainTest(
   // Test some UnicodeStringRef conversion functions
   //------------------------------------------------------
 
-  // Create a UnicodeString with 8 Arabic characters followed by a blank.
+  // Create a icu::UnicodeString with 8 Arabic characters followed by a blank.
   // Also get the utf-8 form as a reference
   UChar uc[] = {0x062c, 0x0648, 0x0631, 0x062c, 0x062a, 0x0627, 0x0648, 0x0646, 0x0020};
   int nchars = sizeof(uc)/sizeof(UChar);
-  UnicodeString US1(uc, nchars);
+  icu::UnicodeString US1(uc, nchars);
   char u8[100];
   US1.extract(0, US1.length(), u8, 100, "utf-8");
 
   // Create two UnicodeStringRef and compare them
   UnicodeStringRef USR1(US1);
   UnicodeStringRef USR2(uc, nchars);
-  if (bVerbose) ucharDisplay(rclConsole, "Construct from UnicodeString", USR1.getBuffer(), USR1.length());
+  if (bVerbose) ucharDisplay(rclConsole, "Construct from icu::UnicodeString", USR1.getBuffer(), USR1.length());
   if (bVerbose) ucharDisplay(rclConsole, "Construct from UChar array",   USR2.getBuffer(), USR2.length());
   ASSERT ( USR1.compare(US1) == 0 );
 
@@ -257,7 +257,7 @@ mainTest(
 
   // Test the "re-try when overflows" logic in unistrref.cpp
   // Create a string that converts to >255 chars
-  UnicodeString US2(uc, nchars);
+  icu::UnicodeString US2(uc, nchars);
   for ( int i=0; i < 15; ++i )
     US2.append(uc, nchars);
 

--- a/src/test/src/test_primitivetypes.cpp
+++ b/src/test/src/test_primitivetypes.cpp
@@ -63,7 +63,8 @@ float floats[] = {
                  };
 
 char chars[] = {
-                 1, 10, 'a','b','c','d','e',8,16,64,128,255
+		/*                 1, 10, 'a','b','c','d','e',8,16,64,128,255*/
+		                1, 10, 'a','b','c','d','e',8,16,64,-128,-1
                };
 
 
@@ -83,10 +84,10 @@ double doubles[] = {
                    };
 
 bool val = false;
-UnicodeString ustr("this beer is good");
-int begin = 1;
-int end = 5;
-char * viewName = "EnglishDocument";
+icu::UnicodeString ustr("this beer is good");
+int Begin = 1;
+int End = 5;
+const char * viewName = "EnglishDocument";
 #define BOOLEAN_ARRAY_SIZE 20
 
 void createExampleFS(CAS & cas, bool copyarrays)  {
@@ -123,7 +124,7 @@ void createExampleFS(CAS & cas, bool copyarrays)  {
   englishView->setDocumentText(ustr);
 
   // create an FS of exampleType and index it
-  AnnotationFS fs = englishView->createAnnotation(testType, begin, end);
+  AnnotationFS fs = englishView->createAnnotation(testType, Begin, End);
   englishView->getIndexRepository().addFS(fs);
 
   // create Array FSs
@@ -453,8 +454,8 @@ void validateFS(CAS & cas, bool checkcopytoarray)  {
   }
   // check scalar values
   ASSERT_OR_THROWEXCEPTION(0==fs.getStringValue(stringF).compare(strings[0]));
-  ASSERT_OR_THROWEXCEPTION(fs.getBeginPosition()==begin);
-  ASSERT_OR_THROWEXCEPTION(fs.getEndPosition()==end);
+  ASSERT_OR_THROWEXCEPTION(fs.getBeginPosition()==Begin);
+  ASSERT_OR_THROWEXCEPTION(fs.getEndPosition()==End);
   ASSERT_OR_THROWEXCEPTION(fs.getFloatValue(floatF)==floats[0]);
   ASSERT_OR_THROWEXCEPTION(fs.getBooleanValue(booleanF)==val);
   ASSERT_OR_THROWEXCEPTION(fs.getByteValue(byteF)=='z');
@@ -487,7 +488,7 @@ void copyArrayExample(CAS & cas) {
   englishView->setDocumentText(ustr);
 
   // create an FS of exampleType and index it
-  AnnotationFS fs = englishView->createAnnotation(testType, begin, end);
+  AnnotationFS fs = englishView->createAnnotation(testType, Begin, End);
   englishView->getIndexRepository().addFS(fs);
 
 }

--- a/src/test/src/test_sofa.cpp
+++ b/src/test/src/test_sofa.cpp
@@ -95,7 +95,7 @@ int main(int argc, char * argv[]) /*
     delete id;
     // Set the document text
 //TODO?   es.setLocalSofaData("this beer is good");
-    es.setLocalSofaData(UnicodeString("this beer is good"));
+    es.setLocalSofaData(icu::UnicodeString("this beer is good"));
 
     // Test Multiple Sofas across XCAS serialization
     outputStream.open("temp.xcas");
@@ -122,7 +122,7 @@ int main(int argc, char * argv[]) /*
 
     // Set the document text
 //TODO?   gerTcas->setDocumentText("das bier ist gut");
-    gerTcas->setDocumentText(UnicodeString("das bier ist gut"));
+    gerTcas->setDocumentText(icu::UnicodeString("das bier ist gut"));
 
     // test getView()->getDocumentAnnotation()->getCoveredText()
     AnnotationFS gerDocAnn = cas->getView("GermanDocument")->getDocumentAnnotation();
@@ -179,7 +179,7 @@ int main(int argc, char * argv[]) /*
 
     // Set the document text off SofaFS after the CAS view exists
 //   frTcas->setSofaDataString("cette biere est bonne", "text");
-    frTcas->setSofaDataString(UnicodeString("cette biere est bonne"), "text");
+    frTcas->setSofaDataString(icu::UnicodeString("cette biere est bonne"), "text");
 
     // Create standard annotations against one and cross annotations against the other
     AnnotationFS engAnnot = engTcas->createAnnotation(annotationType, 0, 4);
@@ -291,7 +291,7 @@ int main(int argc, char * argv[]) /*
     // --------------------------------------------------------
 
 	cas->reset();
-	cas->setDocumentText(UnicodeString("setDocumentText creates the _InitialView Sofa"));
+	cas->setDocumentText(icu::UnicodeString("setDocumentText creates the _InitialView Sofa"));
 	CAS* testView = cas->createView("anotherView");
     ASSERT_OR_THROWEXCEPTION(0 == testView->getViewName().compare("anotherView"));
 	ASSERT_OR_THROWEXCEPTION(0 == cas->getViewName().compare("_InitialView"));
@@ -312,7 +312,7 @@ int main(int argc, char * argv[]) /*
     //Test reading sofa data set as String feature.
 	cas->reset();
     CAS * stringView = cas->createView("StringSofaData");
-    UnicodeString ustrText("this beer is good");
+    icu::UnicodeString ustrText("this beer is good");
     stringView->setDocumentText(ustrText);
     SofaDataStream * pStream = stringView->getSofaDataStream();
     ASSERT_OR_THROWEXCEPTION(pStream != NULL);

--- a/src/test/src/test_xcasdeserialization.cpp
+++ b/src/test/src/test_xcasdeserialization.cpp
@@ -58,8 +58,8 @@ int main(int argc, char * argv[]) /*
 
     TextAnalysisEngineSpecifierBuilder builder;
     TextAnalysisEngineSpecifier apTAESpecifier;
-    UnicodeString dataFile("ExampleCas/testTae.xml");
-    UnicodeString datafn = ResourceManager::resolveFilename(dataFile, dataFile);
+    icu::UnicodeString dataFile("ExampleCas/testTae.xml");
+    icu::UnicodeString datafn = ResourceManager::resolveFilename(dataFile, dataFile);
     builder.buildTaeFromFile(apTAESpecifier, datafn);
 
     internal::CASDefinition * casDef = internal::CASDefinition::createCASDefinition(*apTAESpecifier.getAnalysisEngineMetaData());
@@ -70,13 +70,13 @@ int main(int argc, char * argv[]) /*
     ASSERT_OR_THROWEXCEPTION( EXISTS(v1cas) );
 
     // get a v2 CAS
-    UnicodeString v2casFile("ExampleCas/cas.xml");
-    UnicodeString v2casfn = ResourceManager::resolveFilename(v2casFile, v2casFile);
+    icu::UnicodeString v2casFile("ExampleCas/cas.xml");
+    icu::UnicodeString v2casfn = ResourceManager::resolveFilename(v2casFile, v2casFile);
     XCASDeserializer::deserialize(v2casfn, *cas);
 
     // get a v1.x version of the same CAS
-    UnicodeString v1casFile("ExampleCas/v1cas.xml");
-    UnicodeString v1casfn = ResourceManager::resolveFilename(v1casFile, v1casFile);
+    icu::UnicodeString v1casFile("ExampleCas/v1cas.xml");
+    icu::UnicodeString v1casfn = ResourceManager::resolveFilename(v1casFile, v1casFile);
     XCASDeserializer::deserialize(v1casfn, *v1cas);
 
     // compare
@@ -132,8 +132,8 @@ int main(int argc, char * argv[]) /*
 
 //     // now a v1.x version of a multiple Sofa CAS
     v1cas->reset();
-    UnicodeString v1McasFile("ExampleCas/v1MultiSofaCas.xml");
-    UnicodeString v1Mcasfn = ResourceManager::resolveFilename(v1McasFile, v1McasFile);
+    icu::UnicodeString v1McasFile("ExampleCas/v1MultiSofaCas.xml");
+    icu::UnicodeString v1Mcasfn = ResourceManager::resolveFilename(v1McasFile, v1McasFile);
     XCASDeserializer::deserialize(v1Mcasfn, *v1cas);
 
     // test it

--- a/src/test/src/test_xmideserialization.cpp
+++ b/src/test/src/test_xmideserialization.cpp
@@ -78,11 +78,11 @@ double doubles[] = {
                    };
 
 bool val = false;
-UnicodeString ustr("this beer is good");
-UnicodeString ustrWithXmlEscapeChars("TestingXmlEscapeChars'\"&><\r\n");
-int begin = 1;
-int end = 5;
-char * viewName = "EnglishDocument";
+icu::UnicodeString ustr("this beer is good");
+icu::UnicodeString ustrWithXmlEscapeChars("TestingXmlEscapeChars'\"&><\r\n");
+int Begin = 1;
+int End = 5;
+const char * viewName = "EnglishDocument";
 #define BOOLEAN_ARRAY_SIZE 20
 void validateFS(CAS & cas)  {
 
@@ -216,8 +216,8 @@ void validateFS(CAS & cas)  {
 
   // check scalar values
   ASSERT_OR_THROWEXCEPTION(0==fs.getStringValue(stringF).compare(strings[0]));
-  ASSERT_OR_THROWEXCEPTION(fs.getBeginPosition()==begin);
-  ASSERT_OR_THROWEXCEPTION(fs.getEndPosition()==end);
+  ASSERT_OR_THROWEXCEPTION(fs.getBeginPosition()==Begin);
+  ASSERT_OR_THROWEXCEPTION(fs.getEndPosition()==End);
   ASSERT_OR_THROWEXCEPTION(fs.getFloatValue(floatF)==floats[0]);
   ASSERT_OR_THROWEXCEPTION(fs.getBooleanValue(booleanF)==val);
   ASSERT_OR_THROWEXCEPTION(fs.getByteValue(byteF)=='z');
@@ -277,10 +277,10 @@ void testMultipleSofas(internal::CASDefinition * casDef)  {
     ASSERT_OR_THROWEXCEPTION(EXISTS(cas));
 
     // set document text for the initial view
-    cas->setDocumentText(UnicodeString("This is a test"));
+    cas->setDocumentText(icu::UnicodeString("This is a test"));
     // create a new view and set its document text
     CAS * cas2 = cas->createView("OtherSofa");
-    cas2->setDocumentText(UnicodeString("This is only a test"));
+    cas2->setDocumentText(icu::UnicodeString("This is only a test"));
 
     // create an annotation and add to index of both views
     Type annotType = cas->getTypeSystem().getType(CAS::TYPE_NAME_ANNOTATION);
@@ -313,9 +313,9 @@ void testMultipleSofas(internal::CASDefinition * casDef)  {
     for (int i = 0; i < 2; i++) {
       uima::XmiDeserializer::deserialize("temp.xmi",*newCas);
       // check sofas
-      ASSERT_OR_THROWEXCEPTION(newCas->getDocumentText().compare(UnicodeString("This is a test"))==0);
+      ASSERT_OR_THROWEXCEPTION(newCas->getDocumentText().compare(icu::UnicodeString("This is a test"))==0);
       CAS * newCas2 = newCas->getView("OtherSofa");
-      ASSERT_OR_THROWEXCEPTION(newCas2->getDocumentText().compare(UnicodeString("This is only a test"))==0);
+      ASSERT_OR_THROWEXCEPTION(newCas2->getDocumentText().compare(icu::UnicodeString("This is only a test"))==0);
       ASSERT_OR_THROWEXCEPTION(newCas->getAnnotationIndex().getSize() == 2); // document annot and new Annotation
       ASSERT_OR_THROWEXCEPTION(newCas2->getAnnotationIndex().getSize()== 2); 
       newCas->reset();
@@ -378,8 +378,8 @@ void doTestDeserializeAndReserialize(internal::CASDefinition * casDef) {
   //LOG("deserialize xcas into cas1");
   CAS * cas1 = uima::Framework::createCAS(*casDef, errInfo);
   ASSERT_OR_THROWEXCEPTION( EXISTS(cas1) );
-  UnicodeString xcasFile("ExampleCas/cas.xml");
-  UnicodeString xcasfn = ResourceManager::resolveFilename(xcasFile, xcasFile);
+  icu::UnicodeString xcasFile("ExampleCas/cas.xml");
+  icu::UnicodeString xcasfn = ResourceManager::resolveFilename(xcasFile, xcasFile);
   XCASDeserializer::deserialize(xcasfn, *cas1);
 
   // Serialize Xmi
@@ -434,8 +434,8 @@ void testOotsNewPrimitives(internal::CASDefinition * partialCasDef,
   //LOG("deserialize xcas into cas1 and serialize as XMI");
   CAS * cas1 = uima::Framework::createCAS(*casDef, errInfo);
   ASSERT_OR_THROWEXCEPTION( EXISTS(cas1) );
-  UnicodeString xFile(inputXCas);
-  UnicodeString xfn = ResourceManager::resolveFilename(xFile, xFile);
+  icu::UnicodeString xFile(inputXCas);
+  icu::UnicodeString xfn = ResourceManager::resolveFilename(xFile, xFile);
   XCASDeserializer::deserialize(xfn, *cas1);
 
 	ofstream outputStream;
@@ -477,8 +477,8 @@ void testOotsComplexCas(internal::CASDefinition * partialCasDef,
   //LOG("deserialize xcas into cas1 and serialize as XMI");
   CAS * cas1 = uima::Framework::createCAS(*casDef, errInfo);
   ASSERT_OR_THROWEXCEPTION( EXISTS(cas1) );
-  UnicodeString xFile(inputXCas);
-  UnicodeString xfn = ResourceManager::resolveFilename(xFile, xFile);
+  icu::UnicodeString xFile(inputXCas);
+  icu::UnicodeString xfn = ResourceManager::resolveFilename(xFile, xFile);
   XCASDeserializer::deserialize(xfn, *cas1);
 
 	ofstream outputStream;
@@ -522,7 +522,7 @@ void doTestFSRefReserialization(internal::CASDefinition * casDef) {
   CAS * cas = uima::Framework::createCAS(*casDef, errInfo);
   ASSERT_OR_THROWEXCEPTION( EXISTS(cas) );
   CAS * view = cas->createView("AView");
-  view->setDocumentText(UnicodeString("sample text for AView"));
+  view->setDocumentText(icu::UnicodeString("sample text for AView"));
 
   Type testType = view->getTypeSystem().getType("test.primitives.Example");
   ASSERT_OR_THROWEXCEPTION( testType.isValid() );
@@ -580,8 +580,8 @@ void doTestFSRefReserialization(internal::CASDefinition * casDef) {
   fs1.setFSValue(otherF, otherFS);
   //create a StringArray FS and set StringArrayFS ref feature
   StringArrayFS strArrayFS = view1->createStringArrayFS(5);
-  strArrayFS.set(0,UnicodeString("first string"));
-  strArrayFS.set(1, UnicodeString("second string"));
+  strArrayFS.set(0,icu::UnicodeString("first string"));
+  strArrayFS.set(1, icu::UnicodeString("second string"));
   fs1.setFSValue(stringArrayF, strArrayFS);
 
   //serialize
@@ -643,18 +643,18 @@ int main(int argc, char * argv[]) /*
     TextAnalysisEngineSpecifierBuilder builder;
 	
 	  //setup
-	  UnicodeString tsFile("ExampleCas/testTypeSystem.xml");
-    UnicodeString tsfn = ResourceManager::resolveFilename(tsFile, tsFile);
+	  icu::UnicodeString tsFile("ExampleCas/testTypeSystem.xml");
+    icu::UnicodeString tsfn = ResourceManager::resolveFilename(tsFile, tsFile);
     TypeSystem * ts = Framework::createTypeSystem( ((UnicodeStringRef)tsfn).asUTF8().c_str(),errorInfo);
     ASSERT_OR_THROWEXCEPTION( EXISTS(ts) );
 	
-	  UnicodeString tsFile2("ExampleCas/testTypeSystem_withMultiRefs.xml");
-    UnicodeString tsfn2 = ResourceManager::resolveFilename(tsFile2, tsFile2);
+	  icu::UnicodeString tsFile2("ExampleCas/testTypeSystem_withMultiRefs.xml");
+    icu::UnicodeString tsfn2 = ResourceManager::resolveFilename(tsFile2, tsFile2);
     TypeSystem * ts2 = Framework::createTypeSystem( ((UnicodeStringRef)tsfn2).asUTF8().c_str(),errorInfo);
     ASSERT_OR_THROWEXCEPTION( EXISTS(ts2) );
 
-    UnicodeString indexFile("ExampleCas/testIndexes.xml");
-    UnicodeString indexfn = ResourceManager::resolveFilename(indexFile, indexFile);
+    icu::UnicodeString indexFile("ExampleCas/testIndexes.xml");
+    icu::UnicodeString indexfn = ResourceManager::resolveFilename(indexFile, indexFile);
 	  size_t uiLen = indexfn.length();
     auto_array<UChar> arBuffer( new UChar[uiLen + 1] );
     assert( EXISTS(arBuffer.get()));
@@ -701,24 +701,24 @@ int main(int argc, char * argv[]) /*
 	  TypeSystem * baseTS = Framework::createTypeSystem(*baseTSDesc,"base",errorInfo);
 	  internal::CASDefinition * baseCasDef = internal::CASDefinition::createCASDefinition(*baseTS);
 
-    UnicodeString newpFile("ExampleCas/newprimitivesTypeSystem.xml");
-    UnicodeString newpfn = ResourceManager::resolveFilename(newpFile, newpFile);
+    icu::UnicodeString newpFile("ExampleCas/newprimitivesTypeSystem.xml");
+    icu::UnicodeString newpfn = ResourceManager::resolveFilename(newpFile, newpFile);
 	  TypeSystem *primitivests = Framework::createTypeSystem( ((UnicodeStringRef)newpfn).asUTF8().c_str(),
 										errorInfo );
 	  internal::CASDefinition * primitivesCasDef = 
 	  internal::CASDefinition::createCASDefinition(*primitivests);
 
     LOG("UIMACPP_XMITEST OOTS new primitives missing type Start");
-	  UnicodeString newpxcasFile("ExampleCas/newprimitives.xcas");
-    UnicodeString newpxcasfn = ResourceManager::resolveFilename(newpxcasFile, newpxcasFile);
+	  icu::UnicodeString newpxcasFile("ExampleCas/newprimitives.xcas");
+    icu::UnicodeString newpxcasfn = ResourceManager::resolveFilename(newpxcasFile, newpxcasFile);
     testOotsNewPrimitives(baseCasDef, primitivesCasDef, ((UnicodeStringRef)newpxcasfn).asUTF8().c_str());
      LOG("UIMACPP_XMITEST OOTS new primitives missing type Finished");
 
 
     //test OOTS missing feature
 	  LOG("UIMACPP_XMITEST OOTS new primitives missing feature Start");
-	  UnicodeString newpPartialFile("ExampleCas/newprimitivesPartialTypeSystem.xml");
-    UnicodeString newpPartialfn = ResourceManager::resolveFilename(newpPartialFile, newpFile);
+	  icu::UnicodeString newpPartialFile("ExampleCas/newprimitivesPartialTypeSystem.xml");
+    icu::UnicodeString newpPartialfn = ResourceManager::resolveFilename(newpPartialFile, newpFile);
 	  TypeSystem * newpPartialts = Framework::createTypeSystem( ((UnicodeStringRef)newpPartialfn).asUTF8().c_str(),
 										errorInfo );
 	  internal::CASDefinition * newpPartialCasDef = 
@@ -733,8 +733,8 @@ int main(int argc, char * argv[]) /*
 	  testOotsComplexCas(baseCasDef, casDef, "ExampleCas/cas.xml");
 	  LOG("UIMACPP_XMITEST OOTS Complex CAS Missing Types Finished");
 
-    UnicodeString partialTSFile("ExampleCas/partialTestTypeSystem.xml");
-    UnicodeString partialTSfn = ResourceManager::resolveFilename(partialTSFile, partialTSFile);
+    icu::UnicodeString partialTSFile("ExampleCas/partialTestTypeSystem.xml");
+    icu::UnicodeString partialTSfn = ResourceManager::resolveFilename(partialTSFile, partialTSFile);
 	  TypeSystem * partialts = Framework::createTypeSystem( ((UnicodeStringRef)partialTSfn).asUTF8().c_str(),
 										errorInfo );
 	  internal::CASDefinition * partialTSCasDef = 
@@ -747,8 +747,8 @@ int main(int argc, char * argv[]) /*
 
  		//test that some xml doc fails
     LOG("UIMACPP_XMITEST Valid XML but not Xmi Cas doc Start");
- 		UnicodeString someXmlFile("ExampleCas/cas.xml");
-    UnicodeString xmlfn = ResourceManager::resolveFilename(someXmlFile, someXmlFile);
+ 		icu::UnicodeString someXmlFile("ExampleCas/cas.xml");
+    icu::UnicodeString xmlfn = ResourceManager::resolveFilename(someXmlFile, someXmlFile);
  		CAS * pCas = Framework::createCAS(*casDef,errorInfo);
 
     bool bExceptionThrown = false;

--- a/src/utils/runAECpp.cpp
+++ b/src/utils/runAECpp.cpp
@@ -389,7 +389,7 @@ void process (AnalysisEngine * pEngine, CAS * cas, std::string in, std::string o
       size_t numread = fread(pBuffer,1,filesize,pFile);
       fclose(pFile);
       /* convert to unicode and set tcas document text*/
-      UnicodeString ustrInputText(pBuffer, (int32_t)numread, "utf-8");
+      icu::UnicodeString ustrInputText(pBuffer, (int32_t)numread, "utf-8");
       cas->setDocumentText(UnicodeStringRef(ustrInputText));
       delete[] pBuffer;
     }


### PR DESCRIPTION
The last attempt to split out the commits didn't work so here is a bulk update to C++-17 for discussion.

The big changes are:

Putting unicode string into the icu namespace
auto_ptr->unique_ptr
added a virtual destructor to a base class that needed to (and fixed all the bugs that resulted)
a bunch of things like char is a signed value, in code strings are const, etc.
tempfile creation updated
move to standard map and set in stl
A really insidious bug in the sax interface where the wrong type was used
plus over all cleaning pass